### PR TITLE
Add YAML configuration support and Optuna optimisation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# physae
+# PhysAE
+
+Ce dépôt expose une version modulaire du réseau PhysAE avec une configuration basée sur des fichiers YAML et des utilitaires d'optimisation. Vous trouverez les fichiers de configuration dans `physae/configs` ainsi qu'un carnet Jupyter d'exemple dans `notebooks/optimisation_physae.ipynb`.
+
+## Configurations YAML
+
+* `physae/configs/data/default.yaml` définit les hyperparamètres de génération des données (tailles d'échantillons, intervalles physiques, bruit, etc.).
+* `physae/configs/stages/stage_*.yaml` regroupe les paramètres d'entraînement pour les différentes phases (A, B1, B2) ainsi que les espaces de recherche Optuna associés.
+
+Les fonctions `build_data_and_model` et `train_stage_*` acceptent désormais un argument `config_overrides` permettant d'ajuster ponctuellement les réglages définis dans les fichiers YAML tout en conservant la structure existante.
+
+## Optimisation avec Optuna
+
+Le module `physae.optimization` introduit la fonction `optimise_stage` qui s'appuie sur Optuna pour explorer l'espace de recherche défini dans les fichiers de configuration. Un appel minimal ressemble à ceci :
+
+```python
+from physae.optimization import optimise_stage
+
+study = optimise_stage(
+    "A",
+    n_trials=10,
+    metric="val_loss",
+    data_overrides={"n_train": 2048, "n_val": 256},
+    stage_overrides={"epochs": 8},
+)
+print(study.best_params)
+```
+
+Le carnet `notebooks/optimisation_physae.ipynb` présente un flux complet : chargement des configurations YAML, entraînement rapide des phases A et B, puis optimisation automatique des hyperparamètres.

--- a/notebooks/optimisation_physae.ipynb
+++ b/notebooks/optimisation_physae.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Optimisation PhysAE avec YAML et Optuna"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ce carnet illustre comment configurer les données et les étapes d'entraînement du modèle PhysAE au moyen de fichiers YAML puis comment lancer une recherche d'hyperparamètres avec Optuna.\n\n> 💡 Les cellules sont conçues pour s'exécuter sur un échantillon réduit (quelques centaines de spectres) afin de fournir des démonstrations rapides. Ajustez les tailles et le nombre d'époques pour une expérience complète."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from physae.config_loader import load_data_config, load_stage_config\nfrom physae.factory import build_data_and_model\nfrom physae.training import train_stage_A, train_stage_B2\nfrom physae.optimization import optimise_stage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Aperçu du paramétrage YAML par défaut\nbase_data_cfg = load_data_config()\nbase_stage_A = load_stage_config(\"A\")\nbase_stage_B2 = load_stage_config(\"B2\")\nprint(\"Taille d'entraînement par défaut:", base_data_cfg['n_train'])\nprint(\"Époques pour la phase A:", base_stage_A['epochs'])\nprint(\"Paramètres optimisés pendant la phase B2:", base_stage_B2['optuna'].keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Construction d'un ensemble réduit pour des essais rapides\ndata_overrides = {\n    'n_train': 256,\n    'n_val': 64,\n    'batch_size': 8,\n}\nmodel, train_loader, val_loader = build_data_and_model(config_overrides=data_overrides)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Entraînement rapide de la phase A avec une configuration YAML personnalisée\ntrain_stage_A(\n    model,\n    train_loader,\n    val_loader,\n    config_overrides={'epochs': 5},\n    enable_progress_bar=True,\n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enchaîner sur la phase B2 avec une configuration prédéfinie\ntrain_stage_B2(\n    model,\n    train_loader,\n    val_loader,\n    config_overrides={'epochs': 5},\n    enable_progress_bar=True,\n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optimisation Optuna de la phase A sur un espace de recherche YAML\nstudy = optimise_stage(\n    'A',\n    n_trials=3,\n    metric='val_loss',\n    data_overrides=data_overrides,\n    stage_overrides={'epochs': 5},\n    show_progress_bar=True,\n)\nprint('Meilleurs hyperparamètres:', study.best_params)\nprint('Score associé:', study.best_value)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/physae/__init__.py
+++ b/physae/__init__.py
@@ -6,6 +6,7 @@ from .dataset import SpectraDataset
 from .evaluation import evaluate_and_plot
 from .factory import build_data_and_model
 from .model import PhysicallyInformedAE
+from .optimization import optimise_stage
 from .training import train_stage_A, train_stage_B1, train_stage_B2, train_stage_custom
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "evaluate_and_plot",
     "build_data_and_model",
     "PhysicallyInformedAE",
+    "optimise_stage",
     "train_stage_A",
     "train_stage_B1",
     "train_stage_B2",

--- a/physae/config_loader.py
+++ b/physae/config_loader.py
@@ -1,0 +1,89 @@
+"""Utilities to load YAML based configuration files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping
+
+import yaml
+
+CONFIG_ROOT = Path(__file__).resolve().parent / "configs"
+
+
+def _ensure_path(path: str | Path | None, default: Path) -> Path:
+    if path is None:
+        return default
+    candidate = Path(path)
+    if candidate.is_dir():
+        return candidate
+    return candidate
+
+
+def load_yaml_file(path: str | Path) -> Dict[str, Any]:
+    """Load a YAML document and return a dictionary copy."""
+
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, MutableMapping):
+        raise TypeError(f"Configuration at {path} must define a mapping, got {type(data)!r}.")
+    return dict(data)
+
+
+def load_data_config(path: str | Path | None = None, *, name: str = "default") -> Dict[str, Any]:
+    """Load the dataset/model configuration.
+
+    Args:
+        path: Explicit path to the YAML file or directory containing the configuration.
+        name: Named configuration within ``configs/data`` to resolve when ``path`` points to a
+            directory or is omitted.
+    """
+
+    base = CONFIG_ROOT / "data" / f"{name}.yaml"
+    target = _ensure_path(path, base)
+    if target.is_dir():
+        target = target / f"{name}.yaml"
+    return load_yaml_file(target)
+
+
+def load_stage_config(stage: str, path: str | Path | None = None) -> Dict[str, Any]:
+    """Load the training-stage configuration for ``stage``.
+
+    Args:
+        stage: Stage identifier (e.g. ``"A"`` or ``"B1"``). The lookup is case-insensitive.
+        path: Explicit path to a YAML file or a directory containing the stage configuration.
+    """
+
+    stage_norm = stage.lower()
+    filename = f"stage_{stage_norm}.yaml" if not stage_norm.startswith("stage_") else f"{stage_norm}.yaml"
+    if stage_norm.startswith("stage_"):
+        stage_key = stage_norm.split("stage_", 1)[-1]
+    else:
+        stage_key = stage_norm
+    base = CONFIG_ROOT / "stages" / filename
+    target = _ensure_path(path, base)
+    if target.is_dir():
+        target = target / filename
+    config = load_yaml_file(target)
+    config.setdefault("stage_name", stage_key.upper())
+    return config
+
+
+def merge_dicts(base: Mapping[str, Any], overrides: Mapping[str, Any] | None) -> Dict[str, Any]:
+    """Shallow merge ``base`` with ``overrides`` returning a new dictionary."""
+
+    result: Dict[str, Any] = dict(base)
+    if overrides:
+        for key, value in overrides.items():
+            if isinstance(value, Mapping) and isinstance(result.get(key), Mapping):
+                result[key] = merge_dicts(result[key], value)
+            else:
+                result[key] = value
+    return result
+
+
+def coerce_sequence(values: Iterable[Any] | None) -> list:
+    """Return ``values`` as a concrete list, filtering out ``None`` entries."""
+
+    if values is None:
+        return []
+    return [item for item in values if item is not None]

--- a/physae/configs/data/default.yaml
+++ b/physae/configs/data/default.yaml
@@ -1,0 +1,74 @@
+seed: 42
+n_points: 800
+n_train: 50000
+n_val: 5000
+batch_size: 16
+train_ranges_base:
+  sig0: [3085.43, 3085.46]
+  dsig: [0.001521, 0.00154]
+  mf_CH4: [2.0e-06, 2.0e-05]
+  baseline0: [0.99, 1.01]
+  baseline1: [-0.0004, -0.0003]
+  baseline2: [-4.0565e-08, -3.07117e-08]
+  P: [400, 600]
+  T: [303.15, 313.15]
+train_ranges_expand:
+  _default: 1.0
+  sig0: 5.0
+  dsig: 7.0
+  mf_CH4: 2.0
+  baseline0: 1.0
+  baseline1: 3.0
+  baseline2: 8.0
+  P: 2.0
+  T: 2.0
+val_ranges:
+  sig0: [3085.43, 3085.46]
+  dsig: [0.001521, 0.00154]
+  mf_CH4: [2.0e-06, 2.0e-05]
+  baseline0: [0.99, 1.01]
+  baseline1: [-0.0004, -0.0003]
+  baseline2: [-4.0565e-08, -3.07117e-08]
+  P: [400, 600]
+  T: [303.15, 313.15]
+noise:
+  train:
+    std_add_range: [0, 0.01]
+    std_mult_range: [0, 0.01]
+    p_drift: 0.1
+    drift_sigma_range: [10.0, 120.0]
+    drift_amp_range: [0.004, 0.05]
+    p_fringes: 0.1
+    n_fringes_range: [1, 2]
+    fringe_freq_range: [0.3, 50.0]
+    fringe_amp_range: [0.001, 0.015]
+    p_spikes: 0.1
+    spikes_count_range: [1, 6]
+    spike_amp_range: [0.002, 1.0]
+    spike_width_range: [1.0, 20.0]
+    clip: [0.0, 1.2]
+  val:
+    std_add_range: [0, 1.0e-05]
+    std_mult_range: [0, 1.0e-05]
+    p_drift: 0.0
+    drift_sigma_range: [20.0, 120.0]
+    drift_amp_range: [0.0, 0.01]
+    p_fringes: 0.0
+    n_fringes_range: [1, 2]
+    fringe_freq_range: [0.5, 10.0]
+    fringe_amp_range: [0.0, 0.004]
+    p_spikes: 0.0
+    spikes_count_range: [1, 2]
+    spike_amp_range: [0.0, 0.01]
+    spike_width_range: [1.0, 3.0]
+    clip: [0.0, 1.2]
+predict_list:
+  - sig0
+  - dsig
+  - mf_CH4
+  - P
+  - T
+  - baseline1
+  - baseline2
+film_list: []
+lrs: [0.0001, 1.0e-05]

--- a/physae/configs/stages/stage_A.yaml
+++ b/physae/configs/stages/stage_A.yaml
@@ -1,0 +1,29 @@
+stage_name: A
+epochs: 20
+base_lr: 0.0002
+refiner_lr: 1.0e-06
+train_base: true
+train_heads: true
+train_film: false
+train_refiner: false
+refine_steps: 0
+delta_scale: 0.1
+use_film: false
+film_subset: null
+heads_subset: null
+baseline_fix_enable: false
+enable_progress_bar: false
+optuna:
+  base_lr:
+    type: float
+    low: 1.0e-05
+    high: 1.0e-03
+    log: true
+  epochs:
+    type: int
+    low: 10
+    high: 40
+  delta_scale:
+    type: float
+    low: 0.05
+    high: 0.2

--- a/physae/configs/stages/stage_B1.yaml
+++ b/physae/configs/stages/stage_B1.yaml
@@ -1,0 +1,30 @@
+stage_name: B1
+epochs: 12
+base_lr: 1.0e-06
+refiner_lr: 1.0e-05
+train_base: false
+train_heads: false
+train_film: false
+train_refiner: true
+refine_steps: 2
+delta_scale: 0.12
+use_film: true
+film_subset:
+  - T
+heads_subset: null
+baseline_fix_enable: false
+enable_progress_bar: false
+optuna:
+  refiner_lr:
+    type: float
+    low: 1.0e-06
+    high: 1.0e-03
+    log: true
+  delta_scale:
+    type: float
+    low: 0.05
+    high: 0.2
+  refine_steps:
+    type: int
+    low: 1
+    high: 4

--- a/physae/configs/stages/stage_B2.yaml
+++ b/physae/configs/stages/stage_B2.yaml
@@ -1,0 +1,32 @@
+stage_name: B2
+epochs: 15
+base_lr: 3.0e-05
+refiner_lr: 3.0e-06
+train_base: true
+train_heads: true
+train_film: true
+train_refiner: true
+refine_steps: 2
+delta_scale: 0.08
+use_film: true
+film_subset:
+  - P
+  - T
+heads_subset: null
+baseline_fix_enable: false
+enable_progress_bar: false
+optuna:
+  base_lr:
+    type: float
+    low: 1.0e-05
+    high: 1.0e-03
+    log: true
+  refiner_lr:
+    type: float
+    low: 1.0e-06
+    high: 1.0e-03
+    log: true
+  delta_scale:
+    type: float
+    low: 0.05
+    high: 0.2

--- a/physae/optimization.py
+++ b/physae/optimization.py
@@ -1,0 +1,105 @@
+"""Optuna-based utilities to optimise PhysAE training stages."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+import optuna
+
+from .config_loader import load_data_config, load_stage_config, merge_dicts
+from .factory import build_data_and_model
+from .training import train_stage_custom
+
+
+def _suggest_from_spec(trial: optuna.Trial, name: str, spec: Mapping[str, Any]) -> Any:
+    kind = spec.get("type", "float")
+    if kind == "float":
+        low = float(spec["low"])
+        high = float(spec["high"])
+        step = spec.get("step")
+        log = bool(spec.get("log", False))
+        if step is not None:
+            return trial.suggest_float(name, low, high, step=float(step), log=log)
+        return trial.suggest_float(name, low, high, log=log)
+    if kind == "int":
+        low = int(spec["low"])
+        high = int(spec["high"])
+        step = int(spec.get("step", 1))
+        log = bool(spec.get("log", False))
+        if log:
+            return trial.suggest_int(name, low, high, log=log)
+        return trial.suggest_int(name, low, high, step=step)
+    if kind == "categorical":
+        choices = list(spec["choices"])
+        return trial.suggest_categorical(name, choices)
+    raise ValueError(f"Unknown Optuna parameter type '{kind}' for '{name}'.")
+
+
+def optimise_stage(
+    stage: str,
+    *,
+    n_trials: int = 20,
+    metric: str = "val_loss",
+    direction: str = "minimize",
+    data_config_path: str | None = None,
+    data_config_name: str = "default",
+    data_overrides: Optional[Mapping[str, Any]] = None,
+    stage_config_path: str | None = None,
+    stage_overrides: Optional[Mapping[str, Any]] = None,
+    sampler: optuna.samplers.BaseSampler | None = None,
+    pruner: optuna.pruners.BasePruner | None = None,
+    storage: str | None = None,
+    study_name: str | None = None,
+    show_progress_bar: bool = False,
+) -> optuna.study.Study:
+    """Optimise a training stage using Optuna."""
+
+    if direction not in {"minimize", "maximize"}:
+        raise ValueError("direction must be either 'minimize' or 'maximize'.")
+
+    data_overrides = dict(data_overrides or {})
+    if data_overrides:
+        # Validate overrides early by ensuring the base configuration can be loaded.
+        load_data_config(data_config_path, name=data_config_name)
+
+    def objective(trial: optuna.Trial) -> float:
+        stage_cfg = load_stage_config(stage, path=stage_config_path)
+        if stage_overrides:
+            stage_cfg = merge_dicts(stage_cfg, stage_overrides)
+        search_space = stage_cfg.pop("optuna", {})
+        params: Dict[str, Any] = {}
+        params.update(stage_cfg)
+        for param_name, spec in search_space.items():
+            params[param_name] = _suggest_from_spec(trial, param_name, spec)
+        model, train_loader, val_loader = build_data_and_model(
+            config_path=data_config_path,
+            config_name=data_config_name,
+            config_overrides=data_overrides,
+        )
+        _, metrics = train_stage_custom(
+            model,
+            train_loader,
+            val_loader,
+            **params,
+            return_metrics=True,
+        )
+        if metric not in metrics:
+            raise KeyError(
+                f"Metric '{metric}' not found in trainer callback metrics: {list(metrics)}",
+            )
+        score = float(metrics[metric])
+        trial.set_user_attr("metrics", metrics)
+        return score
+
+    study = optuna.create_study(
+        direction=direction,
+        sampler=sampler,
+        pruner=pruner,
+        storage=storage,
+        study_name=study_name,
+    )
+    study.optimize(objective, n_trials=n_trials, show_progress_bar=show_progress_bar)
+    return study
+
+
+__all__ = ["optimise_stage"]


### PR DESCRIPTION
## Summary
- add reusable YAML configurations for data generation and staged training, plus loader utilities
- update factory and training helpers to consume YAML configs, allow overrides, and expose metrics for tuning
- introduce an Optuna-based optimisation helper, notebook example, and refreshed README documentation

## Testing
- python -m compileall physae

------
https://chatgpt.com/codex/tasks/task_e_68d692b4d4d0832a8511278f3209feb8