### PR TITLE
Add validation helpers and reusable training environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 Ce dépôt expose une version modulaire du réseau PhysAE avec une configuration basée sur des fichiers YAML et des utilitaires d'optimisation. Vous trouverez les fichiers de configuration dans `physae/configs` ainsi qu'un carnet Jupyter d'exemple dans `notebooks/optimisation_physae.ipynb`.
 
+Les modules peuvent maintenant être importés de manière paresseuse (`lazy`) ce qui évite de déclencher immédiatement des dépendances lourdes (PyTorch, Matplotlib, Optuna, …) lorsqu'on ne manipule que la configuration.
+
 ## Configurations YAML
 
 * `physae/configs/data/default.yaml` définit les hyperparamètres de génération des données (tailles d'échantillons, intervalles physiques, bruit, etc.).
 * `physae/configs/stages/stage_*.yaml` regroupe les paramètres d'entraînement pour les différentes phases (A, B1, B2) ainsi que les espaces de recherche Optuna associés.
+* Le module `physae.validation` fournit des fonctions `validate_data_config` et `validate_stage_config` pour vérifier rapidement la cohérence des fichiers YAML (taille des intervalles, clés manquantes, etc.) sans initialiser PyTorch.
 
-Les fonctions `build_data_and_model` et `train_stage_*` acceptent désormais un argument `config_overrides` permettant d'ajuster ponctuellement les réglages définis dans les fichiers YAML tout en conservant la structure existante.
+Les fonctions `build_data_and_model` et `train_stage_*` acceptent toujours un argument `config_overrides` permettant d'ajuster ponctuellement les réglages définis dans les fichiers YAML tout en conservant la structure existante. Pour les usages avancés, `physae.factory.prepare_training_environment` permet de réutiliser un même jeu de DataLoader entre plusieurs entraînements ou essais, et `physae.factory.instantiate_model` crée un nouveau modèle à partir des paramètres sauvegardés dans cet environnement.
 
 ## Optimisation avec Optuna
 
@@ -22,8 +25,9 @@ study = optimise_stage(
     metric="val_loss",
     data_overrides={"n_train": 2048, "n_val": 256},
     stage_overrides={"epochs": 8},
+    reuse_dataloaders=True,
 )
 print(study.best_params)
 ```
 
-Le carnet `notebooks/optimisation_physae.ipynb` présente un flux complet : chargement des configurations YAML, entraînement rapide des phases A et B, puis optimisation automatique des hyperparamètres.
+Le carnet `notebooks/optimisation_physae.ipynb` présente un flux complet : validation des fichiers YAML, construction d'un environnement de données partagé, entraînement rapide des phases A et B, puis optimisation automatique des hyperparamètres en réutilisant les DataLoader.

--- a/notebooks/optimisation_physae.ipynb
+++ b/notebooks/optimisation_physae.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Optimisation PhysAE avec YAML et Optuna"
+    "# Optimisation PhysAE avec validation et réutilisation des données"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ce carnet illustre comment configurer les données et les étapes d'entraînement du modèle PhysAE au moyen de fichiers YAML puis comment lancer une recherche d'hyperparamètres avec Optuna.\n\n> 💡 Les cellules sont conçues pour s'exécuter sur un échantillon réduit (quelques centaines de spectres) afin de fournir des démonstrations rapides. Ajustez les tailles et le nombre d'époques pour une expérience complète."
+    "Ce carnet illustre un flux complet pour contrôler la cohérence des fichiers YAML, préparer un environnement d'entraînement réutilisable, effectuer un entraînement rapide sur les phases A et B2 puis lancer une recherche d'hyperparamètres avec Optuna.\n\n> ⚙️ Les exemples utilisent volontairement de petits jeux de données et quelques époques pour rester rapides. Adaptez les paramètres (tailles, nombres d'époques, etc.) selon vos besoins."
    ]
   },
   {
@@ -20,7 +20,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from physae.config_loader import load_data_config, load_stage_config\nfrom physae.factory import build_data_and_model\nfrom physae.training import train_stage_A, train_stage_B2\nfrom physae.optimization import optimise_stage"
+    "from physae.config_loader import load_data_config, load_stage_config\n",
+    "from physae.validation import validate_data_config, validate_stage_config\n",
+    "from physae.factory import prepare_training_environment\n",
+    "from physae.training import train_stage_A, train_stage_B2\n",
+    "from physae.optimization import optimise_stage\n"
    ]
   },
   {
@@ -29,7 +33,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Aperçu du paramétrage YAML par défaut\nbase_data_cfg = load_data_config()\nbase_stage_A = load_stage_config(\"A\")\nbase_stage_B2 = load_stage_config(\"B2\")\nprint(\"Taille d'entraînement par défaut:", base_data_cfg['n_train'])\nprint(\"Époques pour la phase A:", base_stage_A['epochs'])\nprint(\"Paramètres optimisés pendant la phase B2:", base_stage_B2['optuna'].keys())"
+    "# Vérification rapide des fichiers YAML\n",
+    "data_cfg = load_data_config()\n",
+    "data_report = validate_data_config(data_cfg, name=\"configuration données\")\n",
+    "print(data_report)\n",
+    "for stage in (\"A\", \"B1\", \"B2\"):\n",
+    "    report = validate_stage_config(load_stage_config(stage), name=f\"stage {stage}\")\n",
+    "    print(report)\n"
    ]
   },
   {
@@ -38,7 +48,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Construction d'un ensemble réduit pour des essais rapides\ndata_overrides = {\n    'n_train': 256,\n    'n_val': 64,\n    'batch_size': 8,\n}\nmodel, train_loader, val_loader = build_data_and_model(config_overrides=data_overrides)"
+    "# Construction d'un environnement réutilisable avec un jeu réduit pour des essais rapides\n",
+    "data_overrides = {\n",
+    "    'n_train': 256,\n",
+    "    'n_val': 64,\n",
+    "    'batch_size': 8,\n",
+    "}\n",
+    "env = prepare_training_environment(config_overrides=data_overrides)\n",
+    "env.summary()\n"
    ]
   },
   {
@@ -47,7 +64,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Entraînement rapide de la phase A avec une configuration YAML personnalisée\ntrain_stage_A(\n    model,\n    train_loader,\n    val_loader,\n    config_overrides={'epochs': 5},\n    enable_progress_bar=True,\n)"
+    "# Entraînement rapide de la phase A\n",
+    "model = env.spawn_model()\n",
+    "train_stage_A(\n",
+    "    model,\n",
+    "    env.train_loader,\n",
+    "    env.val_loader,\n",
+    "    config_overrides={'epochs': 5},\n",
+    "    enable_progress_bar=True,\n",
+    ")\n"
    ]
   },
   {
@@ -56,7 +81,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Enchaîner sur la phase B2 avec une configuration prédéfinie\ntrain_stage_B2(\n    model,\n    train_loader,\n    val_loader,\n    config_overrides={'epochs': 5},\n    enable_progress_bar=True,\n)"
+    "# Phase B2 sur le même environnement (les poids de la phase A sont réutilisés)\n",
+    "train_stage_B2(\n",
+    "    model,\n",
+    "    env.train_loader,\n",
+    "    env.val_loader,\n",
+    "    config_overrides={'epochs': 5},\n",
+    "    enable_progress_bar=True,\n",
+    ")\n"
    ]
   },
   {
@@ -65,7 +97,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Optimisation Optuna de la phase A sur un espace de recherche YAML\nstudy = optimise_stage(\n    'A',\n    n_trials=3,\n    metric='val_loss',\n    data_overrides=data_overrides,\n    stage_overrides={'epochs': 5},\n    show_progress_bar=True,\n)\nprint('Meilleurs hyperparamètres:', study.best_params)\nprint('Score associé:', study.best_value)"
+    "# Recherche d'hyperparamètres Optuna sur la phase A\n",
+    "study = optimise_stage(\n",
+    "    'A',\n",
+    "    n_trials=3,\n",
+    "    metric='val_loss',\n",
+    "    data_overrides=data_overrides,\n",
+    "    stage_overrides={'epochs': 5},\n",
+    "    reuse_dataloaders=True,\n",
+    "    show_progress_bar=True,\n",
+    ")\n",
+    "print('Meilleurs hyperparamètres:', study.best_params)\n",
+    "print('Score associé:', study.best_value)\n",
+    "for trial in study.trials:\n",
+    "    metrics = trial.user_attrs.get('metrics', {})\n",
+    "    val_loss = metrics.get('val_loss')\n",
+    "    print(f\"Trial {trial.number}: val_loss={val_loss} params={trial.params}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 Grâce à `prepare_training_environment` les DataLoader sont partagés entre les différentes étapes et entre les essais Optuna, ce qui réduit nettement le coût de préparation. Utilisez `env.spawn_model()` pour obtenir un nouveau réseau lorsque vous souhaitez recommencer un entraînement depuis zéro."
    ]
   }
  ],

--- a/physae/__init__.py
+++ b/physae/__init__.py
@@ -1,13 +1,20 @@
-"""PhysAE package exposing a modular interface for the original project."""
+"""PhysAE package exposing a modular interface for the original project.
+
+This module only imports the lightweight configuration helpers eagerly so that
+sub-packages depending on optional third-party libraries (PyTorch, Optuna,
+Matplotlib, …) can still be imported individually without immediately raising
+``ImportError``.  Heavier objects are exposed through a lazy lookup performed in
+``__getattr__`` which mirrors the behaviour that users expect from
+``from physae import build_data_and_model`` while keeping import side-effects to
+a minimum.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Dict, Tuple
 
 from . import config
-from .callbacks import PlotAndMetricsCallback, UpdateEpochInDataset
-from .dataset import SpectraDataset
-from .evaluation import evaluate_and_plot
-from .factory import build_data_and_model
-from .model import PhysicallyInformedAE
-from .optimization import optimise_stage
-from .training import train_stage_A, train_stage_B1, train_stage_B2, train_stage_custom
 
 __all__ = [
     "config",
@@ -16,10 +23,48 @@ __all__ = [
     "SpectraDataset",
     "evaluate_and_plot",
     "build_data_and_model",
+    "prepare_training_environment",
+    "instantiate_model",
+    "TrainingEnvironment",
     "PhysicallyInformedAE",
     "optimise_stage",
     "train_stage_A",
     "train_stage_B1",
     "train_stage_B2",
     "train_stage_custom",
+    "validate_data_config",
+    "validate_stage_config",
 ]
+
+_LAZY_IMPORTS: Dict[str, Tuple[str, str]] = {
+    "PlotAndMetricsCallback": (".callbacks", "PlotAndMetricsCallback"),
+    "UpdateEpochInDataset": (".callbacks", "UpdateEpochInDataset"),
+    "SpectraDataset": (".dataset", "SpectraDataset"),
+    "evaluate_and_plot": (".evaluation", "evaluate_and_plot"),
+    "build_data_and_model": (".factory", "build_data_and_model"),
+    "prepare_training_environment": (".factory", "prepare_training_environment"),
+    "instantiate_model": (".factory", "instantiate_model"),
+    "TrainingEnvironment": (".factory", "TrainingEnvironment"),
+    "PhysicallyInformedAE": (".model", "PhysicallyInformedAE"),
+    "optimise_stage": (".optimization", "optimise_stage"),
+    "train_stage_A": (".training", "train_stage_A"),
+    "train_stage_B1": (".training", "train_stage_B1"),
+    "train_stage_B2": (".training", "train_stage_B2"),
+    "train_stage_custom": (".training", "train_stage_custom"),
+    "validate_data_config": (".validation", "validate_data_config"),
+    "validate_stage_config": (".validation", "validate_stage_config"),
+}
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin wrapper around importlib
+    if name in _LAZY_IMPORTS:
+        module_name, attribute = _LAZY_IMPORTS[name]
+        module = import_module(module_name, __name__)
+        value = getattr(module, attribute)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial helper
+    return sorted(set(__all__))

--- a/physae/factory.py
+++ b/physae/factory.py
@@ -1,9 +1,11 @@
-"""Factory helpers to build datasets and the PhysAE model."""
+"""Factory helpers to build datasets and PhysAE training environments."""
 
 from __future__ import annotations
 
+import copy
 import sys
-from typing import Any, Dict, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Tuple
 
 import pytorch_lightning as pl
 import torch
@@ -16,7 +18,24 @@ from .model import PhysicallyInformedAE
 from .physics import parse_csv_transitions
 
 
-def _to_tuple_map(mapping: Dict[str, Tuple[float, float]] | Dict[str, list] | None) -> Dict[str, Tuple[float, float]]:
+_POLY_FREQ_CH4 = (-2.3614803e-07, 1.2103413e-10, -3.1617856e-14)
+_TRANSITIONS_CH4_STR = """6;1;3085.861015;1.013E-19;0.06;0.078;219.9411;0.73;-0.00712;0.0;0.0221;0.96;0.584;1.12
+6;1;3085.832038;1.693E-19;0.0597;0.078;219.9451;0.73;-0.00712;0.0;0.0222;0.91;0.173;1.11
+6;1;3085.893769;1.011E-19;0.0602;0.078;219.9366;0.73;-0.00711;0.0;0.0184;1.14;-0.516;1.37
+6;1;3086.030985;1.659E-19;0.0595;0.078;219.9197;0.73;-0.00711;0.0;0.0193;1.17;-0.204;0.97
+6;1;3086.071879;1.000E-19;0.0585;0.078;219.9149;0.73;-0.00703;0.0;0.0232;1.09;-0.0689;0.82
+6;1;3086.085994;6.671E-20;0.055;0.078;219.9133;0.70;-0.00610;0.0;0.0300;0.54;0.00;0.0"""
+
+
+def _base_transitions_dict() -> Dict[str, list]:
+    """Return a fresh copy of the default transition table."""
+
+    return {"CH4": parse_csv_transitions(_TRANSITIONS_CH4_STR)}
+
+
+def _to_tuple_map(
+    mapping: Dict[str, Tuple[float, float]] | Dict[str, list] | None,
+) -> Dict[str, Tuple[float, float]]:
     if mapping is None:
         return {}
     converted: Dict[str, Tuple[float, float]] = {}
@@ -27,7 +46,49 @@ def _to_tuple_map(mapping: Dict[str, Tuple[float, float]] | Dict[str, list] | No
     return converted
 
 
-def build_data_and_model(
+def _normalise_noise(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in cfg.items():
+        if isinstance(value, list):
+            result[key] = tuple(float(v) for v in value)
+        else:
+            result[key] = value
+    return result
+
+
+@dataclass
+class TrainingEnvironment:
+    """Container bundling dataloaders and model kwargs for training."""
+
+    train_loader: DataLoader
+    val_loader: DataLoader
+    model_kwargs: Dict[str, Any]
+    seed: int
+
+    def spawn_model(self, *, seed: int | None = None) -> PhysicallyInformedAE:
+        """Instantiate a new :class:`PhysicallyInformedAE` with optional reseed."""
+
+        if seed is not None:
+            try:  # pragma: no cover - dependency on external library state
+                pl.seed_everything(seed)
+            except Exception:
+                pass
+        return instantiate_model(self.model_kwargs)
+
+    def summary(self) -> Dict[str, Any]:
+        """Return a lightweight summary useful for notebook displays."""
+
+        return {
+            "train_samples": len(self.train_loader.dataset),
+            "val_samples": len(self.val_loader.dataset),
+            "batch_size": self.train_loader.batch_size,
+            "n_points": self.model_kwargs.get("n_points"),
+            "predict_params": list(self.model_kwargs.get("predict_params", [])),
+            "film_params": list(self.model_kwargs.get("film_params", [])),
+        }
+
+
+def prepare_training_environment(
     *,
     seed: int | None = None,
     n_points: int | None = None,
@@ -44,24 +105,23 @@ def build_data_and_model(
     config_path: str | None = None,
     config_name: str = "default",
     config_overrides: Dict[str, Any] | None = None,
-):
+) -> TrainingEnvironment:
+    """Build dataloaders and model kwargs according to the YAML configuration."""
+
     data_config = load_data_config(config_path, name=config_name)
     if config_overrides:
         data_config = merge_dicts(data_config, config_overrides)
 
-    seed = int(seed if seed is not None else data_config.get("seed", 42))
-    pl.seed_everything(seed)
+    seed_value = int(seed if seed is not None else data_config.get("seed", 42))
+    pl.seed_everything(seed_value)
+
     device = "cuda" if torch.cuda.is_available() else "cpu"
     is_windows = sys.platform == "win32"
     num_workers = 0 if is_windows else 4
-    poly_freq_CH4 = [-2.3614803e-07, 1.2103413e-10, -3.1617856e-14]
-    transitions_ch4_str = """6;1;3085.861015;1.013E-19;0.06;0.078;219.9411;0.73;-0.00712;0.0;0.0221;0.96;0.584;1.12
-6;1;3085.832038;1.693E-19;0.0597;0.078;219.9451;0.73;-0.00712;0.0;0.0222;0.91;0.173;1.11
-6;1;3085.893769;1.011E-19;0.0602;0.078;219.9366;0.73;-0.00711;0.0;0.0184;1.14;-0.516;1.37
-6;1;3086.030985;1.659E-19;0.0595;0.078;219.9197;0.73;-0.00711;0.0;0.0193;1.17;-0.204;0.97
-6;1;3086.071879;1.000E-19;0.0585;0.078;219.9149;0.73;-0.00703;0.0;0.0232;1.09;-0.0689;0.82
-6;1;3086.085994;6.671E-20;0.055;0.078;219.9133;0.70;-0.00610;0.0;0.0300;0.54;0.00;0.0"""
-    transitions_dict = {"CH4": parse_csv_transitions(transitions_ch4_str)}
+
+    poly_freq_CH4 = list(_POLY_FREQ_CH4)
+    transitions_dict = _base_transitions_dict()
+
     default_val = {
         "sig0": (3085.43, 3085.46),
         "dsig": (0.001521, 0.00154),
@@ -81,7 +141,7 @@ def build_data_and_model(
         "sig0": 5.0,
         "dsig": 7.0,
         "mf_CH4": 2.0,
-        "baseline0": 1,
+        "baseline0": 1.0,
         "baseline1": 3.0,
         "baseline2": 8.0,
         "P": 2.0,
@@ -97,11 +157,13 @@ def build_data_and_model(
     default_train["mf_CH4"] = (max(lo, config.LOG_FLOOR), max(hi, config.LOG_FLOOR * 10))
     lo, hi = default_val["mf_CH4"]
     default_val["mf_CH4"] = (max(lo, config.LOG_FLOOR), max(hi, config.LOG_FLOOR * 10))
+
     val_ranges = val_ranges or config_val_ranges or default_val
     if train_ranges is None:
         train_ranges = direct_train or default_train
     config.assert_subset(val_ranges, train_ranges, "VAL", "TRAIN")
     config.set_norm_params(train_ranges)
+
     noise_defaults = {
         "train": {
             "std_add_range": (0, 1e-2),
@@ -137,24 +199,17 @@ def build_data_and_model(
         },
     }
 
-    def _normalise_noise(cfg: Dict[str, Any]) -> Dict[str, Any]:
-        result: Dict[str, Any] = {}
-        for key, value in cfg.items():
-            if isinstance(value, list):
-                result[key] = tuple(float(v) for v in value)
-            else:
-                result[key] = value
-        return result
-
     noise_cfg = data_config.get("noise", {})
     noise_train_cfg = noise_cfg.get("train")
     noise_val_cfg = noise_cfg.get("val")
     noise_train = noise_train or _normalise_noise(noise_train_cfg or noise_defaults["train"])
     noise_val = noise_val or _normalise_noise(noise_val_cfg or noise_defaults["val"])
+
     n_points = int(n_points if n_points is not None else data_config.get("n_points", 800))
     n_train = int(n_train if n_train is not None else data_config.get("n_train", 50000))
     n_val = int(n_val if n_val is not None else data_config.get("n_val", 5000))
     batch_size = int(batch_size if batch_size is not None else data_config.get("batch_size", 16))
+
     dataset_train = SpectraDataset(
         n_samples=n_train,
         num_points=n_points,
@@ -177,6 +232,7 @@ def build_data_and_model(
         noise_profile=noise_val,
         freeze_noise=True,
     )
+
     train_loader = DataLoader(
         dataset_train,
         batch_size=batch_size,
@@ -191,6 +247,7 @@ def build_data_and_model(
         num_workers=num_workers,
         pin_memory=(device == "cuda"),
     )
+
     predict_list = predict_list or coerce_sequence(data_config.get("predict_list")) or [
         "sig0",
         "dsig",
@@ -202,32 +259,105 @@ def build_data_and_model(
     ]
     film_list = film_list or coerce_sequence(data_config.get("film_list"))
     lrs = lrs or tuple(float(v) for v in data_config.get("lrs", (1e-4, 1e-5)))
-    model = PhysicallyInformedAE(
+
+    model_transitions = {
+        mol: tuple(dict(item) for item in transitions)
+        for mol, transitions in transitions_dict.items()
+    }
+    model_kwargs = {
+        "n_points": n_points,
+        "param_names": config.PARAMS,
+        "poly_freq_CH4": tuple(poly_freq_CH4),
+        "transitions_dict": model_transitions,
+        "lr": lrs[0],
+        "alpha_param": 0.3,
+        "alpha_phys": 0.7,
+        "head_mode": "multi",
+        "predict_params": list(predict_list),
+        "film_params": list(film_list) if film_list is not None else None,
+        "refine_steps": 1,
+        "refine_delta_scale": 0.1,
+        "refine_target": "noisy",
+        "refine_warmup_epochs": 30,
+        "freeze_base_epochs": 20,
+        "base_lr": lrs[0],
+        "refiner_lr": lrs[1] if len(lrs) > 1 else lrs[0],
+        "baseline_fix_enable": False,
+        "baseline_fix_sideband": 50,
+        "baseline_fix_degree": 2,
+        "baseline_fix_weight": 1.0,
+        "baseline_fix_in_warmup": False,
+        "recon_max1": True,
+        "corr_mode": "none",
+        "corr_savgol_win": 15,
+        "corr_savgol_poly": 3,
+    }
+
+    return TrainingEnvironment(train_loader, val_loader, model_kwargs, seed_value)
+
+
+def instantiate_model(source: Mapping[str, Any] | TrainingEnvironment) -> PhysicallyInformedAE:
+    """Instantiate a :class:`PhysicallyInformedAE` from saved kwargs or an environment."""
+
+    if isinstance(source, TrainingEnvironment):
+        return instantiate_model(source.model_kwargs)
+
+    kwargs = copy.deepcopy(dict(source))
+    kwargs.setdefault("param_names", config.PARAMS)
+    poly_freq = kwargs.get("poly_freq_CH4", _POLY_FREQ_CH4)
+    kwargs["poly_freq_CH4"] = list(poly_freq)
+    transitions_dict = kwargs.get("transitions_dict", {})
+    kwargs["transitions_dict"] = {
+        mol: [dict(item) for item in transitions]
+        for mol, transitions in transitions_dict.items()
+    }
+    return PhysicallyInformedAE(**kwargs)
+
+
+def build_data_and_model(
+    *,
+    seed: int | None = None,
+    n_points: int | None = None,
+    n_train: int | None = None,
+    n_val: int | None = None,
+    batch_size: int | None = None,
+    train_ranges: Dict[str, Tuple[float, float]] | None = None,
+    val_ranges: Dict[str, Tuple[float, float]] | None = None,
+    noise_train: Dict | None = None,
+    noise_val: Dict | None = None,
+    predict_list: list | None = None,
+    film_list: list | None = None,
+    lrs: Tuple[float, float] | None = None,
+    config_path: str | None = None,
+    config_name: str = "default",
+    config_overrides: Dict[str, Any] | None = None,
+):
+    """Backwards-compatible helper returning a model alongside the dataloaders."""
+
+    env = prepare_training_environment(
+        seed=seed,
         n_points=n_points,
-        param_names=config.PARAMS,
-        poly_freq_CH4=poly_freq_CH4,
-        transitions_dict=transitions_dict,
-        lr=lrs[0],
-        alpha_param=0.3,
-        alpha_phys=0.7,
-        head_mode="multi",
-        predict_params=predict_list,
-        film_params=film_list,
-        refine_steps=1,
-        refine_delta_scale=0.1,
-        refine_target="noisy",
-        refine_warmup_epochs=30,
-        freeze_base_epochs=20,
-        base_lr=lrs[0],
-        refiner_lr=lrs[1],
-        baseline_fix_enable=False,
-        baseline_fix_sideband=50,
-        baseline_fix_degree=2,
-        baseline_fix_weight=1.0,
-        baseline_fix_in_warmup=False,
-        recon_max1=True,
-        corr_mode="none",
-        corr_savgol_win=15,
-        corr_savgol_poly=3,
+        n_train=n_train,
+        n_val=n_val,
+        batch_size=batch_size,
+        train_ranges=train_ranges,
+        val_ranges=val_ranges,
+        noise_train=noise_train,
+        noise_val=noise_val,
+        predict_list=predict_list,
+        film_list=film_list,
+        lrs=lrs,
+        config_path=config_path,
+        config_name=config_name,
+        config_overrides=config_overrides,
     )
-    return model, train_loader, val_loader
+    model = instantiate_model(env)
+    return model, env.train_loader, env.val_loader
+
+
+__all__ = [
+    "TrainingEnvironment",
+    "prepare_training_environment",
+    "instantiate_model",
+    "build_data_and_model",
+]

--- a/physae/validation.py
+++ b/physae/validation.py
@@ -1,0 +1,174 @@
+"""Lightweight validation helpers for PhysAE configuration files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
+
+from . import config
+
+
+@dataclass
+class ValidationReport:
+    """Container storing warnings and errors detected during validation."""
+
+    name: str
+    errors: List[str]
+    warnings: List[str]
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.errors
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "errors": list(self.errors), "warnings": list(self.warnings)}
+
+    def __bool__(self) -> bool:  # pragma: no cover - convenience proxy
+        return self.is_valid
+
+    def __str__(self) -> str:
+        status = "✅ OK" if self.is_valid else "⚠️ Erreurs"
+        lines = [f"{self.name}: {status}"]
+        if self.errors:
+            lines.append("  Erreurs:")
+            lines.extend(f"    • {msg}" for msg in self.errors)
+        if self.warnings:
+            lines.append("  Avertissements:")
+            lines.extend(f"    • {msg}" for msg in self.warnings)
+        return "\n".join(lines)
+
+
+def _ensure_interval(value: Any, name: str, *, allow_equal: bool = False) -> Tuple[float, float]:
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ValueError(f"{name} doit être une séquence de longueur 2.")
+    lo, hi = float(value[0]), float(value[1])
+    if allow_equal:
+        if lo > hi:
+            raise ValueError(f"{name} doit vérifier min ≤ max (reçu {lo}, {hi}).")
+    else:
+        if lo >= hi:
+            raise ValueError(f"{name} doit vérifier min < max (reçu {lo}, {hi}).")
+    return lo, hi
+
+
+def _normalise_ranges(ranges: Mapping[str, Any]) -> Dict[str, Tuple[float, float]]:
+    result: Dict[str, Tuple[float, float]] = {}
+    for key, value in ranges.items():
+        result[key] = _ensure_interval(value, f"intervalle '{key}'")
+    return result
+
+
+def validate_data_config(cfg: Mapping[str, Any], *, name: str = "data") -> ValidationReport:
+    """Validate the YAML data configuration without instantiating datasets."""
+
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    for field in ("n_points", "n_train", "n_val", "batch_size"):
+        value = cfg.get(field)
+        if value is None or int(value) <= 0:
+            errors.append(f"{field} doit être strictement positif (reçu {value!r}).")
+
+    try:
+        train_base = _normalise_ranges(cfg.get("train_ranges_base", {}))
+    except ValueError as exc:
+        errors.append(str(exc))
+        train_base = {}
+
+    try:
+        train_direct = _normalise_ranges(cfg.get("train_ranges", {})) if cfg.get("train_ranges") else {}
+    except ValueError as exc:
+        errors.append(str(exc))
+        train_direct = {}
+
+    missing = [param for param in config.PARAMS if param not in (train_direct or train_base)]
+    if missing:
+        errors.append(
+            "Paramètres sans intervalle d'entraînement défini: " + ", ".join(sorted(missing))
+        )
+
+    try:
+        val_ranges = _normalise_ranges(cfg.get("val_ranges", {}))
+    except ValueError as exc:
+        errors.append(str(exc))
+        val_ranges = {}
+
+    if val_ranges:
+        reference_train = train_direct or train_base
+        for name, (vlo, vhi) in val_ranges.items():
+            if name not in reference_train:
+                warnings.append(f"{name} défini pour la validation mais pas pour l'entraînement.")
+                continue
+            tlo, thi = reference_train[name]
+            if not (tlo <= vlo and vhi <= thi):
+                warnings.append(
+                    f"{name}: intervalle validation {vlo:.3g}-{vhi:.3g} hors de l'entraînement {tlo:.3g}-{thi:.3g}."
+                )
+
+    noise_cfg = cfg.get("noise", {}) or {}
+    for split in ("train", "val"):
+        split_cfg = noise_cfg.get(split) or {}
+        for key, value in split_cfg.items():
+            if isinstance(value, (list, tuple)):
+                try:
+                    _ensure_interval(value, f"bruit {split}.{key}", allow_equal=True)
+                except ValueError as exc:
+                    warnings.append(str(exc))
+
+    return ValidationReport(name=name, errors=errors, warnings=warnings)
+
+
+def _validate_bool(cfg: Mapping[str, Any], key: str, errors: List[str]) -> None:
+    if key in cfg and not isinstance(cfg[key], bool):
+        errors.append(f"{key} doit être un booléen (reçu {cfg[key]!r}).")
+
+
+def validate_stage_config(cfg: Mapping[str, Any], *, name: str | None = None) -> ValidationReport:
+    """Validate the configuration of a training stage."""
+
+    stage_name = name or str(cfg.get("stage_name", "?"))
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    for field in ("epochs", "base_lr", "refiner_lr", "refine_steps", "delta_scale"):
+        if field not in cfg:
+            errors.append(f"Champ obligatoire manquant: {field}.")
+    for field in ("epochs", "refine_steps"):
+        if field in cfg and int(cfg[field]) <= 0:
+            errors.append(f"{field} doit être strictement positif (reçu {cfg[field]!r}).")
+    for field in ("base_lr", "refiner_lr", "delta_scale"):
+        if field in cfg and float(cfg[field]) <= 0:
+            errors.append(f"{field} doit être strictement positif (reçu {cfg[field]!r}).")
+
+    for key in ("train_base", "train_heads", "train_film", "train_refiner"):
+        _validate_bool(cfg, key, errors)
+
+    optuna_space = cfg.get("optuna", {}) or {}
+    for param, spec in optuna_space.items():
+        if "type" not in spec:
+            warnings.append(f"{param}: type Optuna non précisé, 'float' sera supposé.")
+            spec_type = "float"
+        else:
+            spec_type = str(spec["type"]).lower()
+        if spec_type in {"float", "int"}:
+            if "low" not in spec or "high" not in spec:
+                errors.append(f"{param}: bornes 'low'/'high' requises pour un paramètre numérique.")
+                continue
+            low, high = float(spec["low"]), float(spec["high"])
+            if low >= high:
+                errors.append(f"{param}: borne low >= high ({low} ≥ {high}).")
+        elif spec_type == "categorical":
+            choices = spec.get("choices")
+            if not isinstance(choices, Iterable) or not list(choices):
+                errors.append(f"{param}: une liste non vide 'choices' est attendue pour un choix catégoriel.")
+        else:
+            errors.append(f"{param}: type Optuna inconnu '{spec_type}'.")
+
+    return ValidationReport(name=f"stage {stage_name}", errors=errors, warnings=warnings)
+
+
+__all__ = [
+    "ValidationReport",
+    "validate_data_config",
+    "validate_stage_config",
+]


### PR DESCRIPTION
## Summary
- add lazy loading in the package init to avoid importing heavy dependencies when only configuration utilities are used
- introduce a reusable TrainingEnvironment factory, Optuna improvements, and configuration validation helpers
- refresh the optimisation notebook and documentation to showcase the validation + optimisation workflow

## Testing
- python -m compileall physae

------
https://chatgpt.com/codex/tasks/task_e_68d69747870c832a933b0f988fc0ce8b