### PR TITLE
Enable EfficientNet and optimizer hyperparameter tuning

### DIFF
--- a/physae/configs/data/default.yaml
+++ b/physae/configs/data/default.yaml
@@ -72,3 +72,25 @@ predict_list:
   - baseline2
 film_list: []
 lrs: [0.0001, 1.0e-05]
+model:
+  encoder:
+    width_mult: 1.0
+    depth_mult: 1.0
+    expand_ratio_scale: 1.0
+    se_ratio: 0.25
+    norm_groups: 8
+  shared_head_hidden_scale: 0.5
+  refiner:
+    width_mult: 1.0
+    depth_mult: 1.0
+    expand_ratio_scale: 1.0
+    se_ratio: 0.25
+    norm_groups: 8
+    hidden_scale: 0.5
+  optimizer:
+    name: adamw
+    betas: [0.9, 0.999]
+    weight_decay: 0.0001
+  scheduler:
+    eta_min: 1.0e-09
+    T_max: null

--- a/physae/configs/stages/stage_A.yaml
+++ b/physae/configs/stages/stage_A.yaml
@@ -27,3 +27,70 @@ optuna:
     type: float
     low: 0.05
     high: 0.2
+  model.encoder.width_mult:
+    type: float
+    low: 0.75
+    high: 1.5
+  model.encoder.depth_mult:
+    type: float
+    low: 0.8
+    high: 1.5
+  model.encoder.expand_ratio_scale:
+    type: float
+    low: 0.8
+    high: 1.3
+  model.encoder.se_ratio:
+    type: float
+    low: 0.15
+    high: 0.35
+  model.encoder.norm_groups:
+    type: categorical
+    choices: [4, 8, 16]
+  model.shared_head_hidden_scale:
+    type: float
+    low: 0.4
+    high: 0.8
+  model.refiner.width_mult:
+    type: float
+    low: 0.75
+    high: 1.5
+  model.refiner.depth_mult:
+    type: float
+    low: 0.8
+    high: 1.5
+  model.refiner.expand_ratio_scale:
+    type: float
+    low: 0.8
+    high: 1.3
+  model.refiner.se_ratio:
+    type: float
+    low: 0.15
+    high: 0.35
+  model.refiner.norm_groups:
+    type: categorical
+    choices: [4, 8, 16]
+  model.refiner.hidden_scale:
+    type: float
+    low: 0.4
+    high: 0.8
+  optimizer:
+    type: categorical
+    choices: [adamw, lion]
+  optimizer_weight_decay:
+    type: float
+    low: 1.0e-06
+    high: 1.0e-03
+    log: true
+  optimizer_beta1:
+    type: float
+    low: 0.85
+    high: 0.99
+  optimizer_beta2:
+    type: float
+    low: 0.9
+    high: 0.9999
+  scheduler_eta_min:
+    type: float
+    low: 1.0e-09
+    high: 1.0e-06
+    log: true

--- a/physae/configs/stages/stage_B1.yaml
+++ b/physae/configs/stages/stage_B1.yaml
@@ -28,3 +28,70 @@ optuna:
     type: int
     low: 1
     high: 4
+  model.encoder.width_mult:
+    type: float
+    low: 0.75
+    high: 1.5
+  model.encoder.depth_mult:
+    type: float
+    low: 0.8
+    high: 1.5
+  model.encoder.expand_ratio_scale:
+    type: float
+    low: 0.8
+    high: 1.3
+  model.encoder.se_ratio:
+    type: float
+    low: 0.15
+    high: 0.35
+  model.encoder.norm_groups:
+    type: categorical
+    choices: [4, 8, 16]
+  model.shared_head_hidden_scale:
+    type: float
+    low: 0.4
+    high: 0.8
+  model.refiner.width_mult:
+    type: float
+    low: 0.75
+    high: 1.5
+  model.refiner.depth_mult:
+    type: float
+    low: 0.8
+    high: 1.5
+  model.refiner.expand_ratio_scale:
+    type: float
+    low: 0.8
+    high: 1.3
+  model.refiner.se_ratio:
+    type: float
+    low: 0.15
+    high: 0.35
+  model.refiner.norm_groups:
+    type: categorical
+    choices: [4, 8, 16]
+  model.refiner.hidden_scale:
+    type: float
+    low: 0.4
+    high: 0.8
+  optimizer:
+    type: categorical
+    choices: [adamw, lion]
+  optimizer_weight_decay:
+    type: float
+    low: 1.0e-06
+    high: 1.0e-03
+    log: true
+  optimizer_beta1:
+    type: float
+    low: 0.85
+    high: 0.99
+  optimizer_beta2:
+    type: float
+    low: 0.9
+    high: 0.9999
+  scheduler_eta_min:
+    type: float
+    low: 1.0e-09
+    high: 1.0e-06
+    log: true

--- a/physae/configs/stages/stage_B2.yaml
+++ b/physae/configs/stages/stage_B2.yaml
@@ -30,3 +30,70 @@ optuna:
     type: float
     low: 0.05
     high: 0.2
+  model.encoder.width_mult:
+    type: float
+    low: 0.75
+    high: 1.5
+  model.encoder.depth_mult:
+    type: float
+    low: 0.8
+    high: 1.5
+  model.encoder.expand_ratio_scale:
+    type: float
+    low: 0.8
+    high: 1.3
+  model.encoder.se_ratio:
+    type: float
+    low: 0.15
+    high: 0.35
+  model.encoder.norm_groups:
+    type: categorical
+    choices: [4, 8, 16]
+  model.shared_head_hidden_scale:
+    type: float
+    low: 0.4
+    high: 0.8
+  model.refiner.width_mult:
+    type: float
+    low: 0.75
+    high: 1.5
+  model.refiner.depth_mult:
+    type: float
+    low: 0.8
+    high: 1.5
+  model.refiner.expand_ratio_scale:
+    type: float
+    low: 0.8
+    high: 1.3
+  model.refiner.se_ratio:
+    type: float
+    low: 0.15
+    high: 0.35
+  model.refiner.norm_groups:
+    type: categorical
+    choices: [4, 8, 16]
+  model.refiner.hidden_scale:
+    type: float
+    low: 0.4
+    high: 0.8
+  optimizer:
+    type: categorical
+    choices: [adamw, lion]
+  optimizer_weight_decay:
+    type: float
+    low: 1.0e-06
+    high: 1.0e-03
+    log: true
+  optimizer_beta1:
+    type: float
+    low: 0.85
+    high: 0.99
+  optimizer_beta2:
+    type: float
+    low: 0.9
+    high: 0.9999
+  scheduler_eta_min:
+    type: float
+    low: 1.0e-09
+    high: 1.0e-06
+    log: true

--- a/physae/models/backbone.py
+++ b/physae/models/backbone.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
 import torch
 import torch.nn as nn
 
@@ -26,21 +30,37 @@ class SqueezeExcitation1D(nn.Module):
         return x * self.se(x)
 
 
+def _resolve_groups(channels: int, desired: int) -> int:
+    desired = max(1, int(desired))
+    channels = max(1, int(channels))
+    groups = math.gcd(channels, desired)
+    return groups if groups > 0 else 1
+
+
 class MBConvBlock1D(nn.Module):
-    def __init__(self, in_channels: int, out_channels: int, kernel: int, stride: int, expand_ratio: int,
-                 se_ratio: float = 0.25) -> None:
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel: int,
+        stride: int,
+        expand_ratio: int,
+        *,
+        se_ratio: float = 0.25,
+        norm_groups: int = 8,
+    ) -> None:
         super().__init__()
         self.use_residual = in_channels == out_channels and stride == 1
         hidden_dim = in_channels * expand_ratio
         reduced_dim = max(1, int(in_channels * se_ratio))
-        num_groups = 8
+        norm_groups = max(1, int(norm_groups))
 
         layers = []
         if expand_ratio != 1:
             layers.append(
                 nn.Sequential(
                     nn.Conv1d(in_channels, hidden_dim, 1, bias=False),
-                    nn.GroupNorm(num_groups, hidden_dim),
+                    nn.GroupNorm(_resolve_groups(hidden_dim, norm_groups), hidden_dim),
                     SiLU(),
                 )
             )
@@ -57,12 +77,12 @@ class MBConvBlock1D(nn.Module):
                         groups=hidden_dim,
                         bias=False,
                     ),
-                    nn.GroupNorm(num_groups, hidden_dim),
+                    nn.GroupNorm(_resolve_groups(hidden_dim, norm_groups), hidden_dim),
                     SiLU(),
                 ),
                 SqueezeExcitation1D(hidden_dim, reduced_dim),
                 nn.Conv1d(hidden_dim, out_channels, 1, bias=False),
-                nn.GroupNorm(max(1, out_channels // num_groups), out_channels),
+                nn.GroupNorm(_resolve_groups(out_channels, norm_groups), out_channels),
             ]
         )
         self.conv = nn.Sequential(*layers)
@@ -71,26 +91,86 @@ class MBConvBlock1D(nn.Module):
         return x + self.conv(x) if self.use_residual else self.conv(x)
 
 
+@dataclass(frozen=True)
+class MBConvConfig:
+    out_channels: int
+    kernel: int
+    stride: int
+    expand_ratio: int
+    repeats: int = 1
+
+
+def _round_channels(value: int, multiplier: float) -> int:
+    scaled = int(round(value * multiplier))
+    return max(4, scaled)
+
+
+def _round_repeats(value: int, multiplier: float) -> int:
+    scaled = int(round(value * multiplier))
+    return max(1, scaled)
+
+
 class EfficientNetEncoder(nn.Module):
-    def __init__(self, in_channels: int = 1) -> None:
+    DEFAULT_BLOCKS: Sequence[MBConvConfig] = (
+        MBConvConfig(out_channels=24, kernel=3, stride=2, expand_ratio=1),
+        MBConvConfig(out_channels=40, kernel=5, stride=2, expand_ratio=6),
+        MBConvConfig(out_channels=80, kernel=3, stride=2, expand_ratio=6),
+        MBConvConfig(out_channels=112, kernel=5, stride=1, expand_ratio=6),
+        MBConvConfig(out_channels=192, kernel=5, stride=2, expand_ratio=6),
+    )
+
+    def __init__(
+        self,
+        in_channels: int = 1,
+        *,
+        width_mult: float = 1.0,
+        depth_mult: float = 1.0,
+        se_ratio: float = 0.25,
+        expand_ratio_scale: float = 1.0,
+        norm_groups: int = 8,
+        block_settings: Sequence[MBConvConfig] | None = None,
+    ) -> None:
         super().__init__()
+        block_settings = tuple(block_settings or self.DEFAULT_BLOCKS)
+        width_mult = float(width_mult)
+        depth_mult = float(depth_mult)
+        expand_ratio_scale = float(expand_ratio_scale)
+        se_ratio = float(se_ratio)
+        norm_groups = int(norm_groups)
+
+        stem_out = _round_channels(32, width_mult)
         self.stem = nn.Sequential(
-            nn.Conv1d(in_channels, 32, 3, 2, 1, bias=False),
-            nn.GroupNorm(8, 32),
+            nn.Conv1d(in_channels, stem_out, 3, 2, 1, bias=False),
+            nn.GroupNorm(_resolve_groups(stem_out, norm_groups), stem_out),
             SiLU(),
         )
-        self.block1 = MBConvBlock1D(32, 24, 3, 2, 1)
-        self.block2 = MBConvBlock1D(24, 40, 5, 2, 6)
-        self.block3 = MBConvBlock1D(40, 80, 3, 2, 6)
-        self.block4 = MBConvBlock1D(80, 112, 5, 1, 6)
-        self.block5 = MBConvBlock1D(112, 192, 5, 2, 6)
-        self.feat_dim = 192
+
+        blocks = []
+        in_channels_current = stem_out
+        for config in block_settings:
+            out_channels = _round_channels(config.out_channels, width_mult)
+            expand_ratio = max(1, int(round(config.expand_ratio * expand_ratio_scale)))
+            repeats = _round_repeats(config.repeats, depth_mult)
+            for repeat_idx in range(repeats):
+                stride = config.stride if repeat_idx == 0 else 1
+                block_in = in_channels_current if repeat_idx == 0 else out_channels
+                blocks.append(
+                    MBConvBlock1D(
+                        block_in,
+                        out_channels,
+                        config.kernel,
+                        stride,
+                        expand_ratio,
+                        se_ratio=se_ratio,
+                        norm_groups=norm_groups,
+                    )
+                )
+                in_channels_current = out_channels
+
+        self.blocks = nn.Sequential(*blocks)
+        self.feat_dim = in_channels_current
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:  # type: ignore[override]
         x = self.stem(x)
-        x = self.block1(x)
-        x = self.block2(x)
-        x = self.block3(x)
-        x = self.block4(x)
-        x = self.block5(x)
+        x = self.blocks(x)
         return x, None

--- a/physae/optimizers.py
+++ b/physae/optimizers.py
@@ -1,0 +1,64 @@
+"""Custom optimizers used by PhysAE."""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+import torch
+from torch.optim import Optimizer
+
+
+class Lion(Optimizer):
+    """Implementation of the Lion optimizer.
+
+    The algorithm is described in https://arxiv.org/abs/2302.06675 and mirrors the
+    reference PyTorch implementation released by the authors. The optimizer uses a
+    sign-based update of an exponential moving average of gradients.
+    """
+
+    def __init__(
+        self,
+        params: Iterable[torch.nn.Parameter],
+        lr: float = 1e-4,
+        betas: Tuple[float, float] = (0.9, 0.99),
+        weight_decay: float = 0.0,
+    ) -> None:
+        if lr <= 0:
+            raise ValueError(f"Invalid learning rate: {lr}")
+        if not 0 <= betas[0] < 1 or not 0 <= betas[1] < 1:
+            raise ValueError(f"Invalid beta parameters: {betas}")
+        defaults = dict(lr=lr, betas=betas, weight_decay=weight_decay)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            beta1, beta2 = group["betas"]
+            lr = group["lr"]
+            weight_decay = group.get("weight_decay", 0.0)
+            for param in group["params"]:
+                if param.grad is None:
+                    continue
+
+                grad = param.grad
+                if weight_decay != 0:
+                    grad = grad.add(param, alpha=weight_decay)
+
+                state = self.state[param]
+                if len(state) == 0:
+                    state["exp_avg"] = torch.zeros_like(param)
+
+                exp_avg = state["exp_avg"]
+                update = exp_avg.mul(beta1).add(grad, alpha=1 - beta1)
+                param.add_(torch.sign(update), alpha=-lr)
+                exp_avg.mul_(beta2).add_(grad, alpha=1 - beta2)
+
+        return loss
+
+
+__all__ = ["Lion"]

--- a/physae/training.py
+++ b/physae/training.py
@@ -95,6 +95,12 @@ def train_stage_custom(
     ckpt_in: Optional[str] = None,
     ckpt_out: Optional[str] = None,
     enable_progress_bar: bool = False,
+    optimizer: Optional[str] = None,
+    optimizer_weight_decay: Optional[float] = None,
+    optimizer_beta1: Optional[float] = None,
+    optimizer_beta2: Optional[float] = None,
+    scheduler_eta_min: Optional[float] = None,
+    scheduler_T_max: Optional[int] = None,
     return_metrics: bool = False,
 ) -> PhysicallyInformedAE | Tuple[PhysicallyInformedAE, Dict[str, float]]:
     print(f"\n===== Stage {stage_name} =====")
@@ -115,6 +121,20 @@ def train_stage_custom(
         model.set_film_subset(film_subset)
     if baseline_fix_enable is not None:
         model.baseline_fix_enable = bool(baseline_fix_enable)
+    if optimizer is not None:
+        model.optimizer_name = str(optimizer).lower()
+    if optimizer_weight_decay is not None:
+        model.optimizer_weight_decay = float(optimizer_weight_decay)
+    beta1, beta2 = model.optimizer_betas
+    if optimizer_beta1 is not None:
+        beta1 = float(optimizer_beta1)
+    if optimizer_beta2 is not None:
+        beta2 = float(optimizer_beta2)
+    model.optimizer_betas = (beta1, beta2)
+    if scheduler_eta_min is not None:
+        model.scheduler_eta_min = float(scheduler_eta_min)
+    if scheduler_T_max is not None:
+        model.scheduler_T_max = int(scheduler_T_max)
     _apply_stage_freeze(
         model,
         train_base=train_base,


### PR DESCRIPTION
## Summary
- make the EfficientNet encoder/refiner configurable (width/depth/expand/se/norm) and add Lion optimizer support
- surface model and optimizer defaults in the data config and extend stage Optuna spaces to explore them
- let stage training update optimizer settings and propagate Optuna overrides into the data configuration

## Testing
- python -m compileall physae

------
https://chatgpt.com/codex/tasks/task_e_68d6a23c61a4832aa5c6cf41947d0996