### PR TITLE
Add comprehensive Read the Docs documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Ce dépôt expose une version modulaire du réseau PhysAE avec une configuration basée sur des fichiers YAML et des utilitaires d'optimisation. Vous trouverez les fichiers de configuration dans `physae/configs` ainsi qu'un carnet Jupyter d'exemple dans `notebooks/optimisation_physae.ipynb`.
 
+## Documentation Read the Docs
+
+Une documentation complète (installation, tutoriel, guide des hyperparamètres) est disponible dans le dossier `docs/` au format Sphinx. Pour la construire localement :
+
+```bash
+pip install -r docs/requirements.txt
+cd docs
+make html
+```
+
+Les pages HTML seront générées dans `docs/_build/html`. Cette structure est compatible avec un déploiement direct sur https://readthedocs.io/.
+
 ## Configurations YAML
 
 * `physae/configs/data/default.yaml` définit les hyperparamètres de génération des données (tailles d'échantillons, intervalles physiques, bruit, etc.).

--- a/docs/api_overview.rst
+++ b/docs/api_overview.rst
@@ -1,0 +1,56 @@
+Panorama des modules
+====================
+
+La bibliothèque est organisée autour de quelques modules clés :
+
+:mod:`physae.factory`
+    Fournit :func:`physae.factory.build_data_and_model` qui instancie le modèle,
+    prépare les jeux de données et applique les paramètres YAML.
+
+:mod:`physae.dataset`
+    Contient :class:`physae.dataset.SpectraDataset` qui génère des paires
+    ``(spectre, paramètres)`` en appelant le moteur physique et en injectant
+    du bruit réaliste via :func:`physae.noise.add_noise_variety`.
+
+:mod:`physae.model`
+    Implémente :class:`physae.model.PhysicallyInformedAE`, un module Lightning
+    avec deux têtes :
+
+    * une tête de reconstruction spectrale (perte ``ReLoBRaLoLoss`` issue de
+      :mod:`physae.losses`) ;
+    * une tête de prédiction de paramètres normalisés avec refinements
+      itératifs (``set_stage_mode`` et ``refine_predictions``).
+
+:mod:`physae.training`
+    Regroupe les fonctions ``train_stage_A/B1/B2`` qui appliquent des schémas de
+    gel/dégel adaptés. Le coeur ``train_stage_custom`` accepte des callbacks
+    Lightning standards et gère la sauvegarde/reprise.
+
+:mod:`physae.optimization`
+    Enveloppe Optuna pour la recherche d'hyperparamètres. La fonction
+    :func:`physae.optimization.optimise_stage` lit la section ``optuna`` des
+    YAML, construit automatiquement l'espace de recherche et retourne un objet
+    :class:`optuna.study.Study`.
+
+:mod:`physae.physics`
+    Offre les primitives de simulation (fonction de Faddeeva, profil de Pine,
+    line mixing). La fonction ``batch_physics_forward_multimol_vgrid`` génère les
+    transmissions spectrales sur la grille ``v_grid``.
+
+:mod:`physae.config`
+    Centralise les noms des paramètres physiques, les bornes de normalisation et
+    des utilitaires pour manipuler les intervalles (``map_ranges`` et
+    ``expand_interval``).
+
+:mod:`physae.config_loader`
+    Lecture et fusion des fichiers YAML. Les fonctions ``merge_dicts`` et
+    ``coerce_sequence`` garantissent une transformation cohérente entre YAML et
+    objets Python.
+
+:mod:`physae.optimizers`
+    Fournit l'implémentation de ``Lion`` (optimiseur "Lookahead AdamW") ainsi
+    que les wrappers nécessaires pour :mod:`torch.optim`.
+
+Pour obtenir une documentation API exhaustive, activez ``sphinx.ext.autodoc``
+et ajoutez ``.. automodule::`` dans vos pages personnalisées. Les options sont
+préconfigurées dans ``docs/conf.py``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from datetime import datetime
+
+# -- Path setup --------------------------------------------------------------
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+project = "PhysAE"
+author = "PhysAE contributors"
+current_year = datetime.utcnow().year
+copyright = f"{current_year}, {author}"
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
+    "sphinx.ext.autosectionlabel",
+]
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "show-inheritance": True,
+}
+
+autosectionlabel_prefix_document = True
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+
+templates_path = ["_templates"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+]
+
+language = "fr"
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+
+primary_domain = "py"
+highlight_language = "python"
+
+todo_include_todos = True

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -1,0 +1,76 @@
+Variations expérimentales
+=========================
+
+Cette section propose des scénarios pour explorer les capacités de PhysAE.
+
+Comparer différentes intensités de bruit
+---------------------------------------
+
+1. Dupliquez ``physae/configs/data/default.yaml`` sous un nouveau nom (ex.
+   ``noisy.yaml``).
+2. Multipliez ``std_add_range`` et ``std_mult_range`` par 5.
+3. Lancez ``build_data_and_model(config_name="noisy")`` puis l'entraînement.
+4. Évaluez l'impact sur ``val_loss`` et les métriques physiques (pression,
+   température).
+
+Tester plusieurs tailles d'échantillon
+--------------------------------------
+
+Utilisez ``data_overrides`` pour modifier ``n_train`` et ``n_val`` lors d'un
+appel à :func:`physae.training.train_stage_A`. Par exemple :
+
+.. code-block:: python
+
+   model, train_loader, val_loader = build_data_and_model(
+       config_overrides={"n_train": 2048, "n_val": 512}
+   )
+
+Puis relancez les trois étapes. Comparez la stabilité des pertes et la variance
+des prédictions.
+
+Balayer ``delta_scale``
+----------------------
+
+Pour évaluer la sensibilité du raffinement, utilisez Optuna ou une boucle
+manuelle :
+
+.. code-block:: python
+
+   for delta in [0.05, 0.1, 0.15, 0.2]:
+       metrics = train_stage_custom(
+           model,
+           train_loader,
+           val_loader,
+           stage_name="B1",
+           epochs=12,
+           base_lr=1e-6,
+           refiner_lr=1e-5,
+           train_base=False,
+           train_heads=False,
+           train_film=False,
+           train_refiner=True,
+           refine_steps=2,
+           delta_scale=delta,
+           return_metrics=True,
+       )[1]
+       print(delta, metrics["val_loss"])
+
+Changer de tête FiLM
+--------------------
+
+Pour comprendre l'influence des conditionnements, modifiez ``film_subset`` :
+
+* ``["T"]`` (par défaut B1) : FiLM basé sur la température.
+* ``["P", "T"]`` (B2) : combinaison pression + température.
+* ``None`` : FiLM désactivé (``use_film=False``).
+
+Observez les écarts sur les paramètres les plus corrélés (moyenne absolue de
+l'erreur sur ``mf_CH4`` et ``sig0``).
+
+Sauvegarde systématique des métriques
+------------------------------------
+
+Couplez :class:`pytorch_lightning.callbacks.ModelCheckpoint` et
+:class:`pytorch_lightning.callbacks.EarlyStopping` pour enregistrer chaque
+variation. Les callbacks se passent via ``callbacks=[...]`` dans
+``train_stage_custom``.

--- a/docs/gases.rst
+++ b/docs/gases.rst
@@ -1,0 +1,93 @@
+Gestion des gaz et transitions
+==============================
+
+Le module :mod:`physae.physics` modélise la génération spectrale en utilisant la
+fonction :func:`physae.physics.batch_physics_forward_multimol_vgrid`. Par
+défaut, la fabrique (:mod:`physae.factory`) configure un dictionnaire de
+transitions contenant uniquement le CH\ :sub:`4`. Voici comment personnaliser la
+physique.
+
+Ajouter un nouveau gaz
+----------------------
+
+1. Récupérez les transitions spectrales (format HITRAN ou personnalisé).
+2. Convertissez-les au format CSV semi-colon séparé attendu par
+   :func:`physae.physics.parse_csv_transitions` (14 colonnes).
+3. Instanciez manuellement :class:`physae.dataset.SpectraDataset` et
+   :class:`physae.model.PhysicallyInformedAE` en fournissant un dictionnaire de
+   transitions enrichi.
+
+.. code-block:: python
+
+   from physae.dataset import SpectraDataset
+   from physae.model import PhysicallyInformedAE
+   from physae.physics import parse_csv_transitions
+   from physae import config
+
+   poly_freq_coeffs = [-2.3614803e-07, 1.2103413e-10, -3.1617856e-14]
+   train_ranges = {
+       "sig0": (3085.43, 3085.46),
+       "dsig": (0.001521, 0.00154),
+       "mf_CH4": (2e-6, 2e-5),
+       "mf_CO2": (5e-6, 5e-5),
+       "baseline0": (0.99, 1.01),
+       "baseline1": (-4e-4, -3e-4),
+       "baseline2": (-4.1e-8, -3.0e-8),
+       "P": (400, 600),
+       "T": (303.15, 313.15),
+   }
+   transitions = {
+       "CH4": parse_csv_transitions(ch4_csv_string),
+       "CO2": parse_csv_transitions(open("co2.csv").read()),
+   }
+   train_dataset = SpectraDataset(
+       n_samples=50000,
+       num_points=800,
+       poly_freq_CH4=poly_freq_coeffs,
+       transitions_dict=transitions,
+       sample_ranges=train_ranges,
+   )
+   model = PhysicallyInformedAE(
+       n_points=800,
+       param_names=config.PARAMS,
+       poly_freq_CH4=poly_freq_coeffs,
+       transitions_dict=transitions,
+       predict_params=["sig0", "dsig", "mf_CH4", "mf_CO2", "P", "T"],
+       film_params=["P", "T"],
+   )
+
+À l'heure actuelle, la fonction :func:`physae.factory.build_data_and_model` se
+concentre sur le cas CH\ :sub:`4`. Pour des scénarios multi-gaz avancés,
+réutilisez les utilitaires ``load_data_config`` et ``merge_dicts`` définis dans
+:mod:`physae.config_loader` pour initialiser vos propres chargeurs de données.
+
+Modifier le maillage spectral
+-----------------------------
+
+``build_data_and_model`` accepte l'argument ``n_points``. Celui-ci influence :
+
+* la longueur des spectres générés par :class:`physae.dataset.SpectraDataset` ;
+* la taille des tenseurs traités par :class:`physae.model.PhysicallyInformedAE` ;
+* le polynôme ``poly_freq_CH4`` utilisé pour générer la grille ``v_grid``
+  (fichier ``factory.py``).
+
+Veillez à ajuster ``poly_freq_CH4`` si le domaine spectral change drastiquement.
+
+Choisir les fractions molaires
+------------------------------
+
+Les fractions sont normalisées logarithmiquement par :func:`physae.config.map_ranges`.
+Pour explorer des concentrations extrêmes, augmentez ``train_ranges_expand``
+(*ex.* ``mf_CH4: 4.0`` double encore les bornes logarithmiques) et gardez
+``val_ranges`` dans l'enveloppe pour éviter les erreurs ``strict_check``.
+
+Contrôler la pression et la température
+---------------------------------------
+
+Les paramètres ``P`` et ``T`` influencent directement la largeur des raies via
+:func:`physae.physics.batch_physics_forward_multimol_vgrid`. Les recommandations :
+
+* définissez ``train_ranges`` suffisamment larges pour couvrir vos conditions
+  expérimentales ;
+* utilisez ``film_subset`` pour conditionner les raffinements FiLM sur les
+  paramètres les plus corrélés aux variations du spectre (souvent ``P`` et ``T``).

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,58 @@
+Premiers pas
+===========
+
+Installation
+------------
+
+Le projet est basé sur PyTorch, PyTorch Lightning et Optuna. Pour reproduire
+l'environnement, créez un nouvel environnement virtuel et installez les
+modules requis :
+
+.. code-block:: bash
+
+   python -m venv .venv
+   source .venv/bin/activate  # sous Windows: .venv\\Scripts\\activate
+   pip install -U pip
+   pip install -e .[dev]
+
+Le paquet ``physae`` est installable en mode editable : toutes les
+modifications locales sont immédiatement disponibles sans réinstallation.
+
+Structure du dépôt
+------------------
+
+``physae/``
+    Contient les modules Python (génération de données, modèle Lightning,
+    fonctions de physique, etc.).
+``physae/configs``
+    Fichiers YAML décrivant les hyperparamètres des données et des différentes
+    étapes d'entraînement.
+``notebooks/``
+    Carnets Jupyter d'exemple, dont ``optimisation_physae.ipynb`` qui illustre
+    un flux complet de formation + recherche d'hyperparamètres.
+``docs/``
+    La documentation Read the Docs présentée ici.
+
+Prérequis physiques
+-------------------
+
+PhysAE cible la reconstruction de spectres CH\ :sub:`4` (méthane) sur un
+maillage spectral défini par ``n_points``. Les paramètres physiques étudiés
+correspondent aux entrées de :data:`physae.config.PARAMS`, notamment la
+position de raie ``sig0``, la largeur ``dsig`` ou encore la fraction molaire
+``mf_CH4``. La normalisation des paramètres est contrôlée par
+:data:`physae.config.NORM_PARAMS`.
+
+Ressources de données
+---------------------
+
+Aucun fichier externe n'est requis : le module :mod:`physae.factory`
+construit automatiquement :
+
+* les dictionnaires de transitions spectraux via
+  :func:`physae.physics.parse_csv_transitions` ;
+* les jeux de données synthétiques via :class:`physae.dataset.SpectraDataset` ;
+* le module Lightning :class:`physae.model.PhysicallyInformedAE`.
+
+Pour modifier la physique (ajout d'un gaz, nouvelles transitions, autre
+maillage), consultez :doc:`gases`.

--- a/docs/hyperparameters.rst
+++ b/docs/hyperparameters.rst
@@ -1,0 +1,91 @@
+Hyperparamètres et réglages
+===========================
+
+Cette section décrit les paramètres disponibles dans les fichiers YAML et leurs
+contreparties dans le code Python.
+
+Configuration des données
+-------------------------
+
+Le fichier :mod:`physae/configs/data/default.yaml <physae/configs/data/default.yaml>`
+définit la génération de spectres.
+
+``n_points``
+    Taille du maillage spectral passé à :class:`physae.dataset.SpectraDataset`.
+    Impose la dimension d'entrée du réseau (``n_points`` est également transmis
+    à :class:`physae.model.PhysicallyInformedAE`).
+``n_train`` / ``n_val``
+    Nombre d'échantillons synthétiques générés à la volée pour les ensembles
+    d'entraînement et de validation.
+``batch_size``
+    Taille du lot PyTorch dans les :class:`~torch.utils.data.DataLoader`.
+``train_ranges_base`` et ``train_ranges_expand``
+    Définissent les intervalles de sampling. Le module :mod:`physae.config`
+    applique ``expand_interval`` afin d'élargir les bornes pour chaque
+    paramètre (méthode logarithmique pour ``mf_CH4``).
+``val_ranges``
+    Intervalles strictement contenus dans ``train_ranges`` pour l'évaluation.
+``noise``
+    Paramètres stochastiques consommés par :func:`physae.noise.add_noise_variety`.
+    Les clés ``std_add_range``, ``std_mult_range`` contrôlent les composantes
+    gaussiennes tandis que ``p_drift``, ``p_fringes`` et ``p_spikes`` activent
+    des perturbations structurées.
+``predict_list`` / ``film_list``
+    Sélection des paramètres prédit par le modèle et de ceux utilisés comme
+    conditionnement FiLM. Les valeurs sont transmises à
+    :class:`physae.model.PhysicallyInformedAE` via :func:`physae.factory.build_data_and_model`.
+``lrs``
+    Paire ``(base_lr, refiner_lr)`` utilisée pour initialiser les taux
+    d'apprentissage des optimisateurs principaux et du raffineur.
+``model``
+    Sous-clefs ``encoder`` et ``refiner`` qui contrôlent la largeur, la
+    profondeur et le facteur ``expand_ratio`` des blocs EfficientNet (cf.
+    :class:`physae.models.EfficientNetEncoder`).
+
+Configurations d'étape
+----------------------
+
+Les fichiers ``physae/configs/stages/stage_*.yaml`` pilotent
+:func:`physae.training.train_stage_custom`.
+
+``epochs``
+    Nombre d'époques Lightning.
+``base_lr`` / ``refiner_lr``
+    Taux utilisés respectivement par l'encodeur (``model.base_lr``) et la tête de
+    raffinement.
+``train_base`` / ``train_heads`` / ``train_film`` / ``train_refiner``
+    Indiquent quelles sous-parties du modèle sont dégelées. Ils déclenchent les
+    appels à ``requires_grad_(True)`` dans :func:`physae.training._apply_stage_freeze`.
+``refine_steps`` / ``delta_scale``
+    Contrôlent le raffinement itératif : ``refine_steps`` définit le nombre de
+    mises à jour successives, ``delta_scale`` la magnitude appliquée aux
+    décalages prédits.
+``use_film`` / ``film_subset`` / ``heads_subset``
+    Permettent d'activer sélectivement la modulation FiLM et de limiter l'entraînement
+    à certaines têtes de sortie.
+``baseline_fix_enable``
+    Active les corrections de baseline gérées par :class:`physae.model.PhysicallyInformedAE`
+    via ``baseline_fix_*``.
+``optimizer``
+    Choix entre ``adamw`` et ``lion`` (voir :mod:`physae.optimizers`). Les
+    paramètres associés (``optimizer_weight_decay``, ``optimizer_beta1``,
+    ``optimizer_beta2``) surchargent ``model.optimizer_*``.
+``scheduler_eta_min`` / ``scheduler_T_max``
+    Paramètres de :class:`torch.optim.lr_scheduler.CosineAnnealingLR` configuré
+    dans :meth:`physae.model.PhysicallyInformedAE.configure_optimizers`.
+
+Bonnes pratiques de sélection
+-----------------------------
+
+* **Étape A** : utilisez un ``base_lr`` plus élevé (1e-4 à 3e-4) pour apprendre
+  rapidement les représentations, sans activer le raffinement.
+* **Étape B1** : abaissez ``refiner_lr`` (1e-6 à 1e-4) et maintenez
+  ``delta_scale`` dans ``[0.05, 0.15]`` pour stabiliser le raffinement.
+* **Étape B2** : réactivez ``train_base`` pour affiner la base avec un
+  ``base_lr`` réduit (3e-5 par défaut) et couplez-le à un ``refiner_lr`` environ
+  dix fois plus faible.
+* **Bruit** : augmentez ``p_drift`` ou ``fringe_amp_range`` pour tester la
+  robustesse aux dérives instrumentales ; fixez ``freeze_noise=True`` dans
+  :class:`physae.dataset.SpectraDataset` pour des benchmarks reproductibles.
+* **Recherche Optuna** : pour limiter l'espace de recherche, réduisez les bornes
+  des hyperparamètres en éditant la section ``optuna`` des fichiers YAML.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,32 @@
+PhysAE
+======
+
+Bienvenue dans la documentation officielle de **PhysAE**, un autoencodeur physique
+pour la reconstruction et l'inférence de spectres infrarouges. Cette
+documentation s'inspire de la mise en page standard `Read the Docs <https://readthedocs.io>`_
+et propose :
+
+* une présentation du projet et de son architecture ;
+* un tutoriel de prise en main complet ;
+* un guide détaillé des hyperparamètres et de leur impact ;
+* des conseils pour créer vos propres expériences (variation de bruit,
+  sélection des gaz, etc.) ;
+* une synthèse des principaux modules Python fournis dans ce dépôt.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Guide utilisateur
+
+   getting_started
+   tutorial
+   hyperparameters
+   gases
+   experiments
+   api_overview
+
+Indices et tables
+-----------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=7.0
+sphinx-rtd-theme>=1.2

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,0 +1,114 @@
+Tutoriel complet
+================
+
+Ce tutoriel montre comment :
+
+1. charger les configurations YAML ;
+2. générer des données synthétiques ;
+3. entraîner successivement les étapes ``A``, ``B1`` et ``B2`` ;
+4. explorer l'espace d'hyperparamètres avec Optuna.
+
+Préparation
+-----------
+
+.. code-block:: python
+
+   from physae.factory import build_data_and_model
+   from physae.training import train_stage_A, train_stage_B1, train_stage_B2
+
+   model, train_loader, val_loader = build_data_and_model(
+       config_path="physae/configs/data",
+       config_name="default",
+   )
+
+La fonction :func:`physae.factory.build_data_and_model` lit le fichier YAML,
+construit un :class:`~physae.dataset.SpectraDataset` pour l'entraînement et la
+validation, et instancie :class:`physae.model.PhysicallyInformedAE` avec les
+paramètres de base (taux d'apprentissage, refinements, film, etc.).
+
+Entraînement par étapes
+-----------------------
+
+Étape A (pré-entraînement des têtes)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   model = train_stage_A(
+       model,
+       train_loader,
+       val_loader,
+       epochs=20,          # surcharge optionnelle
+       base_lr=2e-4,
+       enable_progress_bar=True,
+   )
+
+Cette phase active ``train_base`` et ``train_heads`` (voir
+:func:`physae.training.train_stage_custom`). Aucune étape de raffinement n'est
+lancée (``refine_steps=0``).
+
+Étape B1 (raffinement ciblé)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   model = train_stage_B1(
+       model,
+       train_loader,
+       val_loader,
+       refiner_lr=1e-5,
+       delta_scale=0.12,
+       film_subset=["T"],
+   )
+
+Seule la tête de raffinage est entraînée et les paramètres ``T`` sont utilisés
+pour la modulation FiLM. Le raffinement applique un décalage de ``delta_scale``
+sur les paramètres prédits.
+
+Étape B2 (affinage conjoint)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   model = train_stage_B2(
+       model,
+       train_loader,
+       val_loader,
+       base_lr=3e-5,
+       refiner_lr=3e-6,
+       film_subset=["P", "T"],
+   )
+
+Tous les sous-modèles sont dégelés. Utilisez ``heads_subset`` si vous souhaitez
+ne raffiner qu'une partie des sorties.
+
+Recherche d'hyperparamètres avec Optuna
+---------------------------------------
+
+.. code-block:: python
+
+   from physae.optimization import optimise_stage
+
+   study = optimise_stage(
+       "B2",
+       n_trials=15,
+       metric="val_loss",
+       data_overrides={"n_train": 8192, "noise": {"train": {"p_drift": 0.2}}},
+       stage_overrides={"epochs": 10},
+       show_progress_bar=True,
+   )
+   print("Meilleurs paramètres:", study.best_params)
+   print("Score:", study.best_value)
+
+La clé ``data_overrides`` accepte toute structure conforme au YAML. Les
+paramètres préfixés par ``data.`` dans la section ``optuna`` des fichiers YAML
+sont automatiquement redirigés vers ``data_overrides`` (voir
+:func:`physae.optimization.optimise_stage`).
+
+Sauvegarde & reprise
+--------------------
+
+Les fonctions ``train_stage_*`` acceptent ``ckpt_in`` et ``ckpt_out`` pour
+recharger un point de contrôle Lightning ou sauver les poids finaux. Combinez
+les callbacks Lightning (ex. ``ModelCheckpoint``) avec ``callbacks=[...]`` pour
+personnaliser vos expériences.


### PR DESCRIPTION
## Summary
- add a Sphinx-based documentation tree with landing page, getting started guide, tutorial, and detailed guides on hyperparameters, gas selection, and experiment design
- document module responsibilities and extend the README with build instructions for the new docs

## Testing
- pip install -r docs/requirements.txt *(fails: package downloads blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b596e194832ab44062d1240e020e