### PR TITLE
Allow configuring training accelerator and devices

### DIFF
--- a/docs/api_overview.rst
+++ b/docs/api_overview.rst
@@ -24,7 +24,9 @@ La bibliothèque est organisée autour de quelques modules clés :
 :mod:`physae.training`
     Regroupe les fonctions ``train_stage_A/B1/B2`` qui appliquent des schémas de
     gel/dégel adaptés. Le coeur ``train_stage_custom`` accepte des callbacks
-    Lightning standards et gère la sauvegarde/reprise.
+    Lightning standards, gère la sauvegarde/reprise et permet de spécifier
+    l'accélérateur ``(cpu/gpu)``, le nombre de périphériques et la stratégie DDP
+    pour l'entraînement multi-GPU.
 
 :mod:`physae.optimization`
     Enveloppe Optuna pour la recherche d'hyperparamètres. La fonction

--- a/physae/physae_soumission.txt
+++ b/physae/physae_soumission.txt
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#SBATCH --account=R240011
+#SBATCH --job-name=physae-optuna
+#SBATCH --time=3-00:00:00
+#SBATCH --constraint=armgpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=50G
+#SBATCH --output=%x.%j.out
+#SBATCH --error=%x.%j.err
+
+set -euo pipefail
+set -x
+
+cd "$SLURM_SUBMIT_DIR"
+
+LOGDIR="${PWD}/logs"
+RUNDIR="${PWD}/runs"
+mkdir -p "$LOGDIR" "$RUNDIR"
+
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS="${SLURM_CPUS_PER_TASK:-1}"
+export MKL_NUM_THREADS="${SLURM_CPUS_PER_TASK:-1}"
+export NCCL_ASYNC_ERROR_HANDLING=1
+export NCCL_DEBUG=WARN
+export PYTHONPATH="${PWD}:${PYTHONPATH:-}"
+
+echo "=== ENV ==="
+echo "HOSTNAME=${HOSTNAME:-unknown}"
+echo "JOBID=${SLURM_JOB_ID:-NA} NODELIST=${SLURM_JOB_NODELIST:-NA}"
+echo "NTASKS=${SLURM_NTASKS:-NA} NODES=${SLURM_JOB_NUM_NODES:-NA}"
+
+# --- environnement cluster ---
+romeo_load_armgpu_env
+spack load python@3.13.0/gzl2pkh cuda@12.6.2
+source /home/cosmic_86/envs/pytorch_arm_test/bin/activate
+
+export PHYS_STAGE=${PHYS_STAGE:-B2}                    # A, B1 ou B2
+export PHYS_N_TRIALS=${PHYS_N_TRIALS:-16}
+export PHYS_METRIC=${PHYS_METRIC:-val_loss}
+export PHYS_DATA_CONFIG=${PHYS_DATA_CONFIG:-$PWD/physae/physae/configs/data}
+export PHYS_STAGE_CONFIG=${PHYS_STAGE_CONFIG:-$PWD/physae/physae/configs/stages}
+# export OPTUNA_STORAGE="sqlite:///${RUNDIR}/optuna_${SLURM_JOB_ID}.db"  # optionnel pour reprendre un study
+
+srun --ntasks=1 --cpus-per-task="${SLURM_CPUS_PER_TASK}" --gpus-per-task=1 python - <<'PY'
+import datetime
+import json
+import os
+import pathlib
+
+from physae.optimization import optimise_stage
+
+stage = os.environ.get("PHYS_STAGE", "B2")
+n_trials = int(os.environ.get("PHYS_N_TRIALS", "16"))
+metric = os.environ.get("PHYS_METRIC", "val_loss")
+storage = os.environ.get("OPTUNA_STORAGE") or None
+data_cfg = os.environ.get("PHYS_DATA_CONFIG") or None
+stage_cfg = os.environ.get("PHYS_STAGE_CONFIG") or None
+run_dir = pathlib.Path(os.environ["RUNDIR"])
+run_dir.mkdir(parents=True, exist_ok=True)
+
+study = optimise_stage(
+    stage,
+    n_trials=n_trials,
+    metric=metric,
+    data_config_path=data_cfg,
+    stage_config_path=stage_cfg,
+    storage=storage,
+    study_name=f"{stage.lower()}-{os.environ.get('SLURM_JOB_ID', 'local')}",
+    show_progress_bar=False,
+)
+
+timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+out_file = run_dir / f"optuna_{stage.lower()}_{timestamp}.json"
+payload = {
+    "stage": stage,
+    "n_trials": n_trials,
+    "metric": metric,
+    "best_value": study.best_value,
+    "best_params": study.best_params,
+    "trials": [
+        {
+            "number": trial.number,
+            "value": trial.value,
+            "params": trial.params,
+            "metrics": trial.user_attrs.get("metrics", {}),
+        }
+        for trial in study.trials
+    ],
+}
+out_file.write_text(json.dumps(payload, indent=2))
+print(f"Optuna study saved to {out_file}")
+PY


### PR DESCRIPTION
## Summary
- allow stage configurations to forward accelerator, devices, strategy, precision and num_nodes to the Lightning trainer with automatic DDP when multiple GPUs are requested
- document how to select CPU/GPU or multi-GPU execution and provide an offline SLURM submission example for Optuna runs
- mention the new hardware configuration support in the API overview documentation

## Testing
- python -m compileall physae

------
https://chatgpt.com/codex/tasks/task_e_68d77e679874832a8dc7daedb2ca420f