### PR TITLE
Add high-capacity EfficientNet encoder variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ pip install .[docs]
 
 ## Étendre les composants du modèle
 
-Les éléments clés du modèle (encodeur principal et module de raffinement) sont enregistrés dans des registres afin de faciliter l'ajout de nouvelles variantes. Les constructeurs existants (`efficientnet`) sont déclarés dans `physae/models/backbone.py` et `physae/models/refiner.py` via les décorateurs `@register_encoder` et `@register_refiner`.
+Les éléments clés du modèle (encodeur principal et module de raffinement) sont enregistrés dans des registres afin de faciliter l'ajout de nouvelles variantes. Deux constructeurs d'encodeur sont fournis par défaut :
+
+* `efficientnet`, fidèle au backbone historique.
+* `efficientnet_large`, une déclinaison plus profonde et plus large reposant sur les mêmes blocs MBConv pour des expériences à plus forte capacité.
+
+Ces implémentations sont déclarées dans `physae/models/backbone.py` tandis que les raffinements associés sont définis dans `physae/models/refiner.py` via les décorateurs `@register_encoder` et `@register_refiner`.
 
 Pour ajouter un encodeur personnalisé, il suffit de définir une fonction de construction qui retourne un module `nn.Module` et d'utiliser le décorateur approprié :
 

--- a/physae/models/__init__.py
+++ b/physae/models/__init__.py
@@ -1,6 +1,12 @@
 """Model components for the PhysAE package."""
 
-from .backbone import EfficientNetEncoder, MBConvBlock1D, SiLU, SqueezeExcitation1D
+from .backbone import (
+    EfficientNetEncoder,
+    EfficientNetLargeEncoder,
+    MBConvBlock1D,
+    SiLU,
+    SqueezeExcitation1D,
+)
 from .refiner import EfficientNetRefiner
 from .registry import (
     available_encoders,
@@ -13,6 +19,7 @@ from .registry import (
 
 __all__ = [
     "EfficientNetEncoder",
+    "EfficientNetLargeEncoder",
     "MBConvBlock1D",
     "SiLU",
     "SqueezeExcitation1D",

--- a/physae/models/backbone.py
+++ b/physae/models/backbone.py
@@ -184,3 +184,37 @@ def build_efficientnet_encoder(**kwargs: Any) -> EfficientNetEncoder:
 
     in_channels = int(kwargs.pop("in_channels", 1))
     return EfficientNetEncoder(in_channels=in_channels, **kwargs)
+
+
+class EfficientNetLargeEncoder(EfficientNetEncoder):
+    """More expressive EfficientNet variant tuned for higher-capacity experiments."""
+
+    DEFAULT_BLOCKS: Sequence[MBConvConfig] = (
+        MBConvConfig(out_channels=32, kernel=3, stride=2, expand_ratio=1, repeats=2),
+        MBConvConfig(out_channels=56, kernel=5, stride=2, expand_ratio=6, repeats=4),
+        MBConvConfig(out_channels=112, kernel=3, stride=2, expand_ratio=6, repeats=4),
+        MBConvConfig(out_channels=160, kernel=5, stride=1, expand_ratio=6, repeats=6),
+        MBConvConfig(out_channels=272, kernel=5, stride=2, expand_ratio=6, repeats=2),
+    )
+
+    def __init__(self, in_channels: int = 1, **kwargs: Any) -> None:
+        width_mult = float(kwargs.pop("width_mult", 1.4))
+        depth_mult = float(kwargs.pop("depth_mult", 1.8))
+        expand_ratio_scale = float(kwargs.pop("expand_ratio_scale", 1.2))
+        block_settings = tuple(kwargs.pop("block_settings", self.DEFAULT_BLOCKS))
+        super().__init__(
+            in_channels=in_channels,
+            width_mult=width_mult,
+            depth_mult=depth_mult,
+            expand_ratio_scale=expand_ratio_scale,
+            block_settings=block_settings,
+            **kwargs,
+        )
+
+
+@register_encoder("efficientnet_large")
+def build_efficientnet_large_encoder(**kwargs: Any) -> EfficientNetLargeEncoder:
+    """Build the higher-capacity EfficientNet variant registered as ``efficientnet_large``."""
+
+    in_channels = int(kwargs.pop("in_channels", 1))
+    return EfficientNetLargeEncoder(in_channels=in_channels, **kwargs)


### PR DESCRIPTION
## Summary
- add a higher-capacity EfficientNetLargeEncoder built from MBConv blocks and register it under `efficientnet_large`
- expose the new encoder through the public models package and document the available backbones in the README

## Testing
- python -m compileall physae

------
https://chatgpt.com/codex/tasks/task_e_68d7c3ff8278832a97ebf3079a88d05f