### PR TITLE
Add detailed model guide notebooks

### DIFF
--- a/notebooks/04_guide_efficientnet.ipynb
+++ b/notebooks/04_guide_efficientnet.ipynb
@@ -1,0 +1,266 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Guide complet : encodeur 'efficientnet'\n",
+        "\n",
+        "Ce carnet décrit en détail l'encodeur EfficientNet 1D d'origine utilisé par PhysAE, ainsi que toutes les options modifiables pour l'entraînement et l'inférence."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Pré-requis\n",
+        "\n",
+        "- Python 3.10 ou ultérieur\n",
+        "- PyTorch (CPU ou GPU) et PyTorch Lightning\n",
+        "- Installation locale du paquet `physae` (`pip install -e .` depuis la racine du dépôt)\n",
+        "- Accès aux fichiers de configuration YAML (`physae/configs/...`)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exemple SSH\n",
+        "\n",
+        "Utilisez la commande suivante pour vous connecter à un nœud distant et synchroniser votre dépôt avant l'entraînement :\n",
+        "\n",
+        "```bash\n",
+        "# Connexion SSH\n",
+        "ssh utilisateur@mon-serveur\n",
+        "# Synchronisation du dépôt\n",
+        "git clone git@github.com:mon-org/physae.git\n",
+        "cd physae\n",
+        "python -m venv .venv\n",
+        "source .venv/bin/activate\n",
+        "pip install -e .[train]\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inspection rapide du registre\n",
+        "\n",
+        "Le registre d'encodeurs permet de vérifier que le modèle est disponible :"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.models import available_encoders\n",
+        "\n",
+        "for name in available_encoders():\n",
+        "    print('-', name)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Instanciation de l'encodeur\n",
+        "\n",
+        "On peut construire l'encodeur directement via `build_encoder` pour l'utiliser dans un pipeline personnalisé."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.models import build_encoder\n",
+        "\n",
+        "encoder = build_encoder('efficientnet', in_channels=1)\n",
+        "print(encoder.__class__.__name__)\n",
+        "print('Nombre de paramètres:', sum(p.numel() for p in encoder.parameters()))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Hyperparamètres modifiables\n",
+        "\n",
+        "- `width_mult` *(float, défaut 1.0)* : élargit proportionnellement toutes les largeurs de canaux.\n",
+        "- `depth_mult` *(float, défaut 1.0)* : répète davantage chaque bloc MBConv.\n",
+        "- `se_ratio` *(float, défaut 0.25)* : rapport de compression pour les modules squeeze-and-excitation.\n",
+        "- `expand_ratio_scale` *(float, défaut 1.0)* : multiplie le facteur d'expansion de chaque bloc.\n",
+        "- `norm_groups` *(int, défaut 8)* : nombre de groupes pour la normalisation de groupe.\n",
+        "- `block_settings` *(séquence de `MBConvConfig`)* : structure exacte de la pile de blocs."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Chargement via les configurations YAML\n",
+        "\n",
+        "Voici comment recharger l'encodeur dans le modèle complet PhysAE en limitant la taille du jeu de données pour un test rapide."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.factory import build_data_and_model\n",
+        "\n",
+        "small_data_cfg = {\n",
+        "    'n_points': 256,\n",
+        "    'n_train': 128,\n",
+        "    'n_val': 32,\n",
+        "    'batch_size': 8,\n",
+        "}\n",
+        "\n",
+        "model_bundle = build_data_and_model(\n",
+        "    n_points=small_data_cfg['n_points'],\n",
+        "    n_train=small_data_cfg['n_train'],\n",
+        "    n_val=small_data_cfg['n_val'],\n",
+        "    batch_size=small_data_cfg['batch_size'],\n",
+        "    config_overrides={\n",
+        "        'model': {\n",
+        "            'encoder': {\n",
+        "                'name': 'efficientnet',\n",
+        "                'params': {\n",
+        "                    'width_mult': 1.0\n",
+        "                }\n",
+        "            }\n",
+        "        }\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "model, (train_loader, val_loader), metadata = model_bundle\n",
+        "print(type(model).__name__)\n",
+        "print('Dimensions des entrées attendues :', metadata['input_shape'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Lancement d'un entraînement d'essai\n",
+        "\n",
+        "On peut maintenant lancer un entraînement abrégé (quelques itérations) en ajustant l'entraîneur PyTorch Lightning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.pipeline import train_stages\n",
+        "\n",
+        "train_results = train_stages(\n",
+        "    stages='A',\n",
+        "    max_epochs=1,\n",
+        "    limit_train_batches=5,\n",
+        "    limit_val_batches=2,\n",
+        "    data_overrides={\n",
+        "        'n_train': 128,\n",
+        "        'n_val': 32,\n",
+        "        'batch_size': 8,\n",
+        "    },\n",
+        "    stage_overrides={\n",
+        "        'A': {\n",
+        "            'model': {\n",
+        "                'encoder': {\n",
+        "                    'name': 'efficientnet'\n",
+        "                }\n",
+        "            }\n",
+        "        }\n",
+        "    },\n",
+        "    trainer_kwargs={\n",
+        "        'accelerator': 'cpu',\n",
+        "        'devices': 1,\n",
+        "        'max_epochs': 1,\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "print(train_results.metrics['A'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Personnalisation avancée\n",
+        "\n",
+        "L'encodeur renvoie un tenseur de caractéristiques et peut être couplé à n'importe quel raffineur enregistré. Les paramètres supplémentaires fournis à `build_encoder` sont transmis directement au constructeur `EfficientNetEncoder`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Exemple de modification du YAML\n",
+        "\n",
+        "```yaml\n",
+        "model:\n",
+        "  encoder:\n",
+        "    name: efficientnet\n",
+        "    params:\n",
+        "      width_mult: 0.75\n",
+        "      depth_mult: 1.2\n",
+        "      norm_groups: 4\n",
+        "```\n",
+        "\n",
+        "Enregistrez ce fragment dans un fichier puis passez-le à `--stage-overrides` ou fusionnez-le via `config_overrides`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inférence et export\n",
+        "\n",
+        "Une fois le modèle entraîné, utilisez `physae.cli` pour effectuer une inférence ou exporter les prédictions :"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "```bash\n",
+        "physae optimise --stages A --n-trials 5 --metric val_loss --output-dir studies\n",
+        "physae train --stages A --studies-dir studies --devices 1 --accelerator cpu\n",
+        "physae predict --checkpoint chemin/vers/last.ckpt --output predictions.parquet\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Aller plus loin\n",
+        "\n",
+        "- Tester différents jeux d'hyperparamètres avec Optuna (`physae.optimization`).\n",
+        "- Modifier `train_ranges` et `noise` dans `physae/configs/data`.\n",
+        "- Brancher un raffineur personnalisé via `register_refiner`."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/notebooks/05_guide_efficientnet_large.ipynb
+++ b/notebooks/05_guide_efficientnet_large.ipynb
@@ -1,0 +1,265 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Guide complet : encodeur 'efficientnet_large'\n",
+        "\n",
+        "Cette variante augmente la capacité de l'encodeur en élargissant et en approfondissant les blocs MBConv."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Pré-requis\n",
+        "\n",
+        "- Python 3.10 ou ultérieur\n",
+        "- PyTorch (CPU ou GPU) et PyTorch Lightning\n",
+        "- Installation locale du paquet `physae` (`pip install -e .` depuis la racine du dépôt)\n",
+        "- Accès aux fichiers de configuration YAML (`physae/configs/...`)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exemple SSH\n",
+        "\n",
+        "Pour réserver un GPU et lancer un entraînement longue durée via SSH :\n",
+        "\n",
+        "```bash\n",
+        "# Connexion SSH\n",
+        "ssh utilisateur@mon-serveur\n",
+        "# Synchronisation du dépôt\n",
+        "git clone git@github.com:mon-org/physae.git\n",
+        "cd physae\n",
+        "python -m venv .venv\n",
+        "source .venv/bin/activate\n",
+        "pip install -e .[train]\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inspection rapide du registre\n",
+        "\n",
+        "Le registre d'encodeurs permet de vérifier que le modèle est disponible :"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.models import available_encoders\n",
+        "\n",
+        "for name in available_encoders():\n",
+        "    print('-', name)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Instanciation de l'encodeur\n",
+        "\n",
+        "On peut construire l'encodeur directement via `build_encoder` pour l'utiliser dans un pipeline personnalisé."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.models import build_encoder\n",
+        "\n",
+        "encoder = build_encoder('efficientnet_large', in_channels=1)\n",
+        "print(encoder.__class__.__name__)\n",
+        "print('Nombre de paramètres:', sum(p.numel() for p in encoder.parameters()))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Hyperparamètres modifiables\n",
+        "\n",
+        "- `width_mult` *(float, défaut 1.4)* : coefficient d'élargissement appliqué aux couches.\n",
+        "- `depth_mult` *(float, défaut 1.8)* : multiplie le nombre de répétitions de chaque bloc.\n",
+        "- `expand_ratio_scale` *(float, défaut 1.2)* : augmente la largeur interne des blocs MBConv.\n",
+        "- `norm_groups` *(int, défaut 8)* : groupes utilisés par GroupNorm.\n",
+        "- `block_settings` *(séquence de `MBConvConfig`)* : configuration détaillée, répétée par défaut pour couvrir de larges profondeurs."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Chargement via les configurations YAML\n",
+        "\n",
+        "Voici comment recharger l'encodeur dans le modèle complet PhysAE en limitant la taille du jeu de données pour un test rapide."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.factory import build_data_and_model\n",
+        "\n",
+        "small_data_cfg = {\n",
+        "    'n_points': 256,\n",
+        "    'n_train': 128,\n",
+        "    'n_val': 32,\n",
+        "    'batch_size': 8,\n",
+        "}\n",
+        "\n",
+        "model_bundle = build_data_and_model(\n",
+        "    n_points=small_data_cfg['n_points'],\n",
+        "    n_train=small_data_cfg['n_train'],\n",
+        "    n_val=small_data_cfg['n_val'],\n",
+        "    batch_size=small_data_cfg['batch_size'],\n",
+        "    config_overrides={\n",
+        "        'model': {\n",
+        "            'encoder': {\n",
+        "                'name': 'efficientnet_large',\n",
+        "                'params': {\n",
+        "                    'width_mult': 1.0\n",
+        "                }\n",
+        "            }\n",
+        "        }\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "model, (train_loader, val_loader), metadata = model_bundle\n",
+        "print(type(model).__name__)\n",
+        "print('Dimensions des entrées attendues :', metadata['input_shape'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Lancement d'un entraînement d'essai\n",
+        "\n",
+        "On peut maintenant lancer un entraînement abrégé (quelques itérations) en ajustant l'entraîneur PyTorch Lightning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.pipeline import train_stages\n",
+        "\n",
+        "train_results = train_stages(\n",
+        "    stages='A',\n",
+        "    max_epochs=1,\n",
+        "    limit_train_batches=5,\n",
+        "    limit_val_batches=2,\n",
+        "    data_overrides={\n",
+        "        'n_train': 128,\n",
+        "        'n_val': 32,\n",
+        "        'batch_size': 8,\n",
+        "    },\n",
+        "    stage_overrides={\n",
+        "        'A': {\n",
+        "            'model': {\n",
+        "                'encoder': {\n",
+        "                    'name': 'efficientnet_large'\n",
+        "                }\n",
+        "            }\n",
+        "        }\n",
+        "    },\n",
+        "    trainer_kwargs={\n",
+        "        'accelerator': 'cpu',\n",
+        "        'devices': 1,\n",
+        "        'max_epochs': 1,\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "print(train_results.metrics['A'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Personnalisation avancée\n",
+        "\n",
+        "Idéal pour des phases B lorsque la contrainte mémoire est moindre. Vous pouvez aussi réduire `width_mult` ou `depth_mult` pour des tests rapides."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Exemple de modification du YAML\n",
+        "\n",
+        "```yaml\n",
+        "model:\n",
+        "  encoder:\n",
+        "    name: efficientnet_large\n",
+        "    params:\n",
+        "      width_mult: 0.75\n",
+        "      depth_mult: 1.2\n",
+        "      norm_groups: 4\n",
+        "```\n",
+        "\n",
+        "Enregistrez ce fragment dans un fichier puis passez-le à `--stage-overrides` ou fusionnez-le via `config_overrides`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inférence et export\n",
+        "\n",
+        "Une fois le modèle entraîné, utilisez `physae.cli` pour effectuer une inférence ou exporter les prédictions :"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "```bash\n",
+        "physae optimise --stages A --n-trials 5 --metric val_loss --output-dir studies\n",
+        "physae train --stages A --studies-dir studies --devices 1 --accelerator cpu\n",
+        "physae predict --checkpoint chemin/vers/last.ckpt --output predictions.parquet\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Aller plus loin\n",
+        "\n",
+        "- Tester différents jeux d'hyperparamètres avec Optuna (`physae.optimization`).\n",
+        "- Modifier `train_ranges` et `noise` dans `physae/configs/data`.\n",
+        "- Brancher un raffineur personnalisé via `register_refiner`."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/notebooks/06_guide_efficientnet_v2.ipynb
+++ b/notebooks/06_guide_efficientnet_v2.ipynb
@@ -1,0 +1,265 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Guide complet : encodeur 'efficientnet_v2'\n",
+        "\n",
+        "L'encodeur EfficientNet-V2 combine blocs MBConv classiques et blocs fusionnés pour accélérer l'entraînement tout en conservant une bonne précision."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Pré-requis\n",
+        "\n",
+        "- Python 3.10 ou ultérieur\n",
+        "- PyTorch (CPU ou GPU) et PyTorch Lightning\n",
+        "- Installation locale du paquet `physae` (`pip install -e .` depuis la racine du dépôt)\n",
+        "- Accès aux fichiers de configuration YAML (`physae/configs/...`)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exemple SSH\n",
+        "\n",
+        "Connexion SSH typique pour un serveur multi-GPU :\n",
+        "\n",
+        "```bash\n",
+        "# Connexion SSH\n",
+        "ssh utilisateur@mon-serveur\n",
+        "# Synchronisation du dépôt\n",
+        "git clone git@github.com:mon-org/physae.git\n",
+        "cd physae\n",
+        "python -m venv .venv\n",
+        "source .venv/bin/activate\n",
+        "pip install -e .[train]\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inspection rapide du registre\n",
+        "\n",
+        "Le registre d'encodeurs permet de vérifier que le modèle est disponible :"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.models import available_encoders\n",
+        "\n",
+        "for name in available_encoders():\n",
+        "    print('-', name)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Instanciation de l'encodeur\n",
+        "\n",
+        "On peut construire l'encodeur directement via `build_encoder` pour l'utiliser dans un pipeline personnalisé."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.models import build_encoder\n",
+        "\n",
+        "encoder = build_encoder('efficientnet_v2', in_channels=1)\n",
+        "print(encoder.__class__.__name__)\n",
+        "print('Nombre de paramètres:', sum(p.numel() for p in encoder.parameters()))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Hyperparamètres modifiables\n",
+        "\n",
+        "- `width_mult` *(float, défaut 1.0)* : facteur d'élargissement.\n",
+        "- `depth_mult` *(float, défaut 1.0)* : facteur de répétition.\n",
+        "- `expand_ratio_scale` *(float, défaut 1.0)* : ajuste tous les rapports d'expansion.\n",
+        "- `norm_groups` *(int, défaut 8)* : nombre de groupes pour GroupNorm.\n",
+        "- `block_settings` *(séquence de `MBConvConfig`)* : décrit l'alternance blocs fused/MBConv."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Chargement via les configurations YAML\n",
+        "\n",
+        "Voici comment recharger l'encodeur dans le modèle complet PhysAE en limitant la taille du jeu de données pour un test rapide."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.factory import build_data_and_model\n",
+        "\n",
+        "small_data_cfg = {\n",
+        "    'n_points': 256,\n",
+        "    'n_train': 128,\n",
+        "    'n_val': 32,\n",
+        "    'batch_size': 8,\n",
+        "}\n",
+        "\n",
+        "model_bundle = build_data_and_model(\n",
+        "    n_points=small_data_cfg['n_points'],\n",
+        "    n_train=small_data_cfg['n_train'],\n",
+        "    n_val=small_data_cfg['n_val'],\n",
+        "    batch_size=small_data_cfg['batch_size'],\n",
+        "    config_overrides={\n",
+        "        'model': {\n",
+        "            'encoder': {\n",
+        "                'name': 'efficientnet_v2',\n",
+        "                'params': {\n",
+        "                    'width_mult': 1.0\n",
+        "                }\n",
+        "            }\n",
+        "        }\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "model, (train_loader, val_loader), metadata = model_bundle\n",
+        "print(type(model).__name__)\n",
+        "print('Dimensions des entrées attendues :', metadata['input_shape'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Lancement d'un entraînement d'essai\n",
+        "\n",
+        "On peut maintenant lancer un entraînement abrégé (quelques itérations) en ajustant l'entraîneur PyTorch Lightning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.pipeline import train_stages\n",
+        "\n",
+        "train_results = train_stages(\n",
+        "    stages='A',\n",
+        "    max_epochs=1,\n",
+        "    limit_train_batches=5,\n",
+        "    limit_val_batches=2,\n",
+        "    data_overrides={\n",
+        "        'n_train': 128,\n",
+        "        'n_val': 32,\n",
+        "        'batch_size': 8,\n",
+        "    },\n",
+        "    stage_overrides={\n",
+        "        'A': {\n",
+        "            'model': {\n",
+        "                'encoder': {\n",
+        "                    'name': 'efficientnet_v2'\n",
+        "                }\n",
+        "            }\n",
+        "        }\n",
+        "    },\n",
+        "    trainer_kwargs={\n",
+        "        'accelerator': 'cpu',\n",
+        "        'devices': 1,\n",
+        "        'max_epochs': 1,\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "print(train_results.metrics['A'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Personnalisation avancée\n",
+        "\n",
+        "Cette variante est particulièrement adaptée aux environnements où la vitesse prime : les premiers blocs `fused` évitent le coût des convolutions depthwise."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Exemple de modification du YAML\n",
+        "\n",
+        "```yaml\n",
+        "model:\n",
+        "  encoder:\n",
+        "    name: efficientnet_v2\n",
+        "    params:\n",
+        "      width_mult: 0.75\n",
+        "      depth_mult: 1.2\n",
+        "      norm_groups: 4\n",
+        "```\n",
+        "\n",
+        "Enregistrez ce fragment dans un fichier puis passez-le à `--stage-overrides` ou fusionnez-le via `config_overrides`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inférence et export\n",
+        "\n",
+        "Une fois le modèle entraîné, utilisez `physae.cli` pour effectuer une inférence ou exporter les prédictions :"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "```bash\n",
+        "physae optimise --stages A --n-trials 5 --metric val_loss --output-dir studies\n",
+        "physae train --stages A --studies-dir studies --devices 1 --accelerator cpu\n",
+        "physae predict --checkpoint chemin/vers/last.ckpt --output predictions.parquet\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Aller plus loin\n",
+        "\n",
+        "- Tester différents jeux d'hyperparamètres avec Optuna (`physae.optimization`).\n",
+        "- Modifier `train_ranges` et `noise` dans `physae/configs/data`.\n",
+        "- Brancher un raffineur personnalisé via `register_refiner`."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/notebooks/07_guide_convnext.ipynb
+++ b/notebooks/07_guide_convnext.ipynb
@@ -1,0 +1,266 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Guide complet : encodeur 'convnext'\n",
+        "\n",
+        "Le bloc ConvNeXt 1D reprend la philosophie des architectures ConvNeXt avec normalisation de type LayerNorm."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Pré-requis\n",
+        "\n",
+        "- Python 3.10 ou ultérieur\n",
+        "- PyTorch (CPU ou GPU) et PyTorch Lightning\n",
+        "- Installation locale du paquet `physae` (`pip install -e .` depuis la racine du dépôt)\n",
+        "- Accès aux fichiers de configuration YAML (`physae/configs/...`)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exemple SSH\n",
+        "\n",
+        "Script SSH pour lancer une session d'entraînement distribuée :\n",
+        "\n",
+        "```bash\n",
+        "# Connexion SSH\n",
+        "ssh utilisateur@mon-serveur\n",
+        "# Synchronisation du dépôt\n",
+        "git clone git@github.com:mon-org/physae.git\n",
+        "cd physae\n",
+        "python -m venv .venv\n",
+        "source .venv/bin/activate\n",
+        "pip install -e .[train]\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inspection rapide du registre\n",
+        "\n",
+        "Le registre d'encodeurs permet de vérifier que le modèle est disponible :"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.models import available_encoders\n",
+        "\n",
+        "for name in available_encoders():\n",
+        "    print('-', name)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Instanciation de l'encodeur\n",
+        "\n",
+        "On peut construire l'encodeur directement via `build_encoder` pour l'utiliser dans un pipeline personnalisé."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.models import build_encoder\n",
+        "\n",
+        "encoder = build_encoder('convnext', in_channels=1)\n",
+        "print(encoder.__class__.__name__)\n",
+        "print('Nombre de paramètres:', sum(p.numel() for p in encoder.parameters()))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Hyperparamètres modifiables\n",
+        "\n",
+        "- `depths` *(tuple d'int, défaut (3, 3, 9, 3))* : nombre de blocs par stade.\n",
+        "- `dims` *(tuple d'int, défaut (96, 192, 384, 768))* : largeur des canaux à chaque stade.\n",
+        "- `drop_path_rate` *(float, défaut 0.0)* : probabilité de stochastic depth.\n",
+        "- `kernel_size` *(int, défaut 7)* : taille du noyau depthwise.\n",
+        "- `layer_scale_init_value` *(float, défaut 1e-6)* : initialisation de l'échelle résiduelle.\n",
+        "- `norm_eps` *(float, défaut 1e-6)* : epsilon de la LayerNorm1d."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Chargement via les configurations YAML\n",
+        "\n",
+        "Voici comment recharger l'encodeur dans le modèle complet PhysAE en limitant la taille du jeu de données pour un test rapide."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.factory import build_data_and_model\n",
+        "\n",
+        "small_data_cfg = {\n",
+        "    'n_points': 256,\n",
+        "    'n_train': 128,\n",
+        "    'n_val': 32,\n",
+        "    'batch_size': 8,\n",
+        "}\n",
+        "\n",
+        "model_bundle = build_data_and_model(\n",
+        "    n_points=small_data_cfg['n_points'],\n",
+        "    n_train=small_data_cfg['n_train'],\n",
+        "    n_val=small_data_cfg['n_val'],\n",
+        "    batch_size=small_data_cfg['batch_size'],\n",
+        "    config_overrides={\n",
+        "        'model': {\n",
+        "            'encoder': {\n",
+        "                'name': 'convnext',\n",
+        "                'params': {\n",
+        "                    'width_mult': 1.0\n",
+        "                }\n",
+        "            }\n",
+        "        }\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "model, (train_loader, val_loader), metadata = model_bundle\n",
+        "print(type(model).__name__)\n",
+        "print('Dimensions des entrées attendues :', metadata['input_shape'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Lancement d'un entraînement d'essai\n",
+        "\n",
+        "On peut maintenant lancer un entraînement abrégé (quelques itérations) en ajustant l'entraîneur PyTorch Lightning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from physae.pipeline import train_stages\n",
+        "\n",
+        "train_results = train_stages(\n",
+        "    stages='A',\n",
+        "    max_epochs=1,\n",
+        "    limit_train_batches=5,\n",
+        "    limit_val_batches=2,\n",
+        "    data_overrides={\n",
+        "        'n_train': 128,\n",
+        "        'n_val': 32,\n",
+        "        'batch_size': 8,\n",
+        "    },\n",
+        "    stage_overrides={\n",
+        "        'A': {\n",
+        "            'model': {\n",
+        "                'encoder': {\n",
+        "                    'name': 'convnext'\n",
+        "                }\n",
+        "            }\n",
+        "        }\n",
+        "    },\n",
+        "    trainer_kwargs={\n",
+        "        'accelerator': 'cpu',\n",
+        "        'devices': 1,\n",
+        "        'max_epochs': 1,\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "print(train_results.metrics['A'])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Personnalisation avancée\n",
+        "\n",
+        "ConvNeXt offre une capacité représentative élevée mais nécessite un ajustement de l'apprentissage (p. ex. augmenter le batch ou utiliser un scheduler cosine)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Exemple de modification du YAML\n",
+        "\n",
+        "```yaml\n",
+        "model:\n",
+        "  encoder:\n",
+        "    name: convnext\n",
+        "    params:\n",
+        "      width_mult: 0.75\n",
+        "      depth_mult: 1.2\n",
+        "      norm_groups: 4\n",
+        "```\n",
+        "\n",
+        "Enregistrez ce fragment dans un fichier puis passez-le à `--stage-overrides` ou fusionnez-le via `config_overrides`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inférence et export\n",
+        "\n",
+        "Une fois le modèle entraîné, utilisez `physae.cli` pour effectuer une inférence ou exporter les prédictions :"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "```bash\n",
+        "physae optimise --stages A --n-trials 5 --metric val_loss --output-dir studies\n",
+        "physae train --stages A --studies-dir studies --devices 1 --accelerator cpu\n",
+        "physae predict --checkpoint chemin/vers/last.ckpt --output predictions.parquet\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Aller plus loin\n",
+        "\n",
+        "- Tester différents jeux d'hyperparamètres avec Optuna (`physae.optimization`).\n",
+        "- Modifier `train_ranges` et `noise` dans `physae/configs/data`.\n",
+        "- Brancher un raffineur personnalisé via `register_refiner`."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add four new notebooks covering the EfficientNet, EfficientNet Large, EfficientNet V2 and ConvNeXt encoders
- document SSH setup, configuration overrides, quick training loops and YAML customisation for each backbone
- provide ready-to-run code cells for registry inspection, model instantiation, data/model creation, trial training and CLI usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7cb1fc424832ab1e0ba0866f03f15