### PR TITLE
Normalize refiner config legacy keys

### DIFF
--- a/physae/model.py
+++ b/physae/model.py
@@ -198,6 +198,18 @@ class PhysicallyInformedAE(pl.LightningModule):
             self.out_heads = nn.ModuleDict({name: nn.Linear(hidden, 1) for name in self.predict_params})
 
         refiner_kwargs = dict(refiner_config or {})
+        legacy_to_new = {
+            "width_mult": "encoder_width_mult",
+            "depth_mult": "encoder_depth_mult",
+            "expand_ratio_scale": "encoder_expand_ratio_scale",
+            "se_ratio": "encoder_se_ratio",
+            "norm_groups": "encoder_norm_groups",
+            "hidden_scale": "hidden_scale",
+        }
+        for legacy_key, new_key in legacy_to_new.items():
+            if legacy_key in refiner_kwargs:
+                value = refiner_kwargs.pop(legacy_key)
+                refiner_kwargs.setdefault(new_key, value)
         refiner_kwargs.setdefault("m_params", len(self.predict_params))
         refiner_kwargs.setdefault("cond_dim", self.cond_dim)
         refiner_kwargs.setdefault("backbone_feat_dim", feat_dim)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,40 @@
+"""Smoke tests for the public factory helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("pytorch_lightning")
+
+from physae.factory import build_data_and_model
+
+
+def test_build_data_and_model_supports_legacy_refiner_keys() -> None:
+    """Ensure the refiner accepts legacy configuration keys via overrides."""
+
+    model, train_loader, val_loader = build_data_and_model(
+        config_overrides={
+            "n_train": 1,
+            "n_val": 1,
+            "batch_size": 1,
+            "model": {
+                "refiner": {
+                    # ``width_mult`` is the historical key that should now map to
+                    # ``encoder_width_mult`` inside the refiner kwargs.
+                    "width_mult": 0.75,
+                }
+            },
+        }
+    )
+
+    assert model.refiner is not None
+    assert train_loader is not None
+    assert val_loader is not None


### PR DESCRIPTION
## Summary
- normalize refiner configuration kwargs in `PhysicallyInformedAE` to map legacy keys onto the new prefixed names
- add a factory smoke test ensuring `build_data_and_model` still accepts legacy refiner overrides

## Testing
- pytest tests/test_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68d7d4298f54832abd8dd884498b37f3