### PR TITLE
Fix noise normalisation to preserve integer ranges

### DIFF
--- a/physae/factory.py
+++ b/physae/factory.py
@@ -138,10 +138,12 @@ def build_data_and_model(
     }
 
     def _normalise_noise(cfg: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert list based intervals to tuples preserving element types."""
+
         result: Dict[str, Any] = {}
         for key, value in cfg.items():
             if isinstance(value, list):
-                result[key] = tuple(float(v) for v in value)
+                result[key] = tuple(value)
             else:
                 result[key] = value
         return result

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+pytest.importorskip("torch")
+
+from physae.factory import build_data_and_model
+
+
+def test_noise_integer_ranges_generate_batches_without_error():
+    train_loader, _, _ = build_data_and_model(
+        n_points=32,
+        n_train=4,
+        n_val=2,
+        batch_size=2,
+        config_overrides={
+            "noise": {
+                "train": {
+                    "n_fringes_range": [1, 2],
+                    "spikes_count_range": [1, 3],
+                }
+            }
+        },
+    )
+
+    noise_range = train_loader.dataset.noise_profile["n_fringes_range"]
+    assert noise_range == (1, 2)
+    assert all(isinstance(v, int) for v in noise_range)
+
+    batch = next(iter(train_loader))
+    spectra, _ = batch
+    assert spectra.shape[0] > 0


### PR DESCRIPTION
## Summary
- preserve noise configuration element types when normalising list-based intervals
- add a regression test that builds a small data/model bundle and iterates one batch without integer noise ranges failing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7d616a720832a83bd899398b7c28c