### PR TITLE
Fix sampling of integer noise parameters when ranges are floats

### DIFF
--- a/physae/noise.py
+++ b/physae/noise.py
@@ -40,7 +40,15 @@ def add_noise_variety(spectra: torch.Tensor, *, generator=None, **config) -> tor
         return (torch.rand((), device=device, generator=generator) * (b - a) + a).item()
 
     def rand_int(a, b):
-        return int(torch.randint(a, b + 1, (), device=device, generator=generator).item())
+        low = math.ceil(a)
+        high = math.floor(b)
+        if low > high:
+            raise ValueError(
+                "Invalid integer range: lower bound is greater than upper bound"
+            )
+        return int(
+            torch.randint(low, high + 1, (), device=device, generator=generator).item()
+        )
 
     def rand_bool(p):
         return bool(torch.rand((), device=device, generator=generator) < p)


### PR DESCRIPTION
## Summary
- clamp integer noise parameter ranges to valid bounds before sampling
- raise a descriptive error when no integers fall within the provided range

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7e1d615d0832a850c4fc8db20c86e