### PR TITLE
Handle drift noise padding for small spectra

### DIFF
--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,0 +1,27 @@
+"""Tests for noise generation utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from physae.noise import add_noise_variety
+
+
+def test_add_noise_variety_handles_small_signals():
+    """Ensure the drift padding logic works for very short spectra."""
+
+    generator = torch.Generator(device="cpu").manual_seed(1234)
+    spectra = torch.zeros((2, 256), dtype=torch.float32)
+
+    out = add_noise_variety(
+        spectra,
+        generator=generator,
+        drift_sigma_range=(80.0, 90.0),
+        p_drift=1.0,
+        p_fringes=0.0,
+        p_spikes=0.0,
+    )
+
+    assert out.shape == spectra.shape


### PR DESCRIPTION
## Summary
- prevent the drift noise smoother from requesting reflect padding larger than the spectrum length
- normalise the truncated gaussian kernel robustly when sigma is very small
- add a regression test ensuring `add_noise_variety` works when the spectra have few samples

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7e2ec495c832abe0b5025db38a974