### PR TITLE
Return metadata from build_data_and_model

### DIFF
--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -21,7 +21,7 @@ appel à :func:`physae.training.train_stage_A`. Par exemple :
 
 .. code-block:: python
 
-   model, train_loader, val_loader = build_data_and_model(
+   model, (train_loader, val_loader), _ = build_data_and_model(
        config_overrides={"n_train": 2048, "n_val": 512}
    )
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -16,10 +16,12 @@ Préparation
    from physae.factory import build_data_and_model
    from physae.training import train_stage_A, train_stage_B1, train_stage_B2
 
-   model, train_loader, val_loader = build_data_and_model(
+   model, (train_loader, val_loader), metadata = build_data_and_model(
        config_path="physae/configs/data",
        config_name="default",
    )
+
+   print("Dimensions des entrées attendues :", metadata["input_shape"])
 
 La fonction :func:`physae.factory.build_data_and_model` lit le fichier YAML,
 construit un :class:`~physae.dataset.SpectraDataset` pour l'entraînement et la

--- a/physae/cli.py
+++ b/physae/cli.py
@@ -178,7 +178,7 @@ def cmd_train(args: argparse.Namespace) -> None:
 
 def cmd_infer(args: argparse.Namespace) -> None:
     overrides = _load_mapping(args.data_overrides)
-    model, _, val_loader = build_data_and_model(
+    model, (_, val_loader), _ = build_data_and_model(
         config_path=args.data_config_path,
         config_name=args.data_config_name,
         config_overrides=overrides or None,

--- a/physae/factory.py
+++ b/physae/factory.py
@@ -294,4 +294,19 @@ def build_data_and_model(
         scheduler_eta_min=float(scheduler_cfg.get("eta_min", 1e-9)),
         scheduler_T_max=scheduler_t_max,
     )
-    return model, train_loader, val_loader
+
+    metadata = {
+        "input_shape": (n_points,),
+        "train_size": n_train,
+        "val_size": n_val,
+        "batch_size": batch_size,
+        "train_ranges": train_ranges,
+        "val_ranges": val_ranges,
+        "noise_train": noise_train,
+        "noise_val": noise_val,
+        "predict_list": predict_list,
+        "film_list": film_list,
+        "lrs": lrs,
+    }
+
+    return model, (train_loader, val_loader), metadata

--- a/physae/optimization.py
+++ b/physae/optimization.py
@@ -160,7 +160,7 @@ def optimise_stage(
                 params[param_name] = value
         trial.set_user_attr("stage_params", copy.deepcopy(params))
         trial.set_user_attr("data_overrides", copy.deepcopy(trial_data_overrides))
-        model, train_loader, val_loader = build_data_and_model(
+        model, (train_loader, val_loader), _ = build_data_and_model(
             config_path=data_config_path,
             config_name=data_config_name,
             config_overrides=trial_data_overrides or None,

--- a/physae/pipeline.py
+++ b/physae/pipeline.py
@@ -162,7 +162,7 @@ def train_stages(
     if missing:
         raise KeyError(f"Paramètres manquants pour les stages: {', '.join(missing)}")
     overrides = dict(data_overrides or {})
-    model, train_loader, val_loader = build_data_and_model(
+    model, (train_loader, val_loader), _ = build_data_and_model(
         config_path=data_config_path,
         config_name=data_config_name,
         config_overrides=overrides or None,

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -38,9 +38,11 @@ def test_build_data_and_model_default_refiner_config():
     from physae.factory import build_data_and_model
     from physae.model import PhysicallyInformedAE
 
-    model, train_loader, val_loader = build_data_and_model(**_small_build_kwargs())
+    model, (train_loader, val_loader), metadata = build_data_and_model(**_small_build_kwargs())
 
     assert isinstance(model, PhysicallyInformedAE)
+
+    assert metadata["input_shape"] == (32,)
 
     batch = next(iter(train_loader))
     assert batch["noisy_spectra"].ndim == 2
@@ -72,7 +74,7 @@ def test_noise_integer_ranges_generate_batches_without_error():
         "clip": (0.0, 1.5),
     }
 
-    _, train_loader, _ = build_data_and_model(
+    _, (train_loader, _), _ = build_data_and_model(
         **_small_build_kwargs(noise_train=integer_noise, noise_val=integer_noise)
     )
 


### PR DESCRIPTION
## Summary
- include loader metadata in the `build_data_and_model` return value
- adjust internal uses, docs, and tests to unpack the new structure

## Testing
- pytest tests/test_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68d82b5f4394832a81e1b008222cf8e4