### PR TITLE
Add training and Optuna workflow notebooks

### DIFF
--- a/notebooks/08_training_workflow.ipynb
+++ b/notebooks/08_training_workflow.ipynb
@@ -1,0 +1,397 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Guide pratique : entraînement PhysAE avec des configurations fixes",
+        "",
+        "Ce carnet illustre comment préparer les données, sélectionner un backbone, ajuster les hyperparamètres d'entraînement et recueillir les métriques pour chaque variante de modèle disponible dans PhysAE. Toutes les cellules peuvent être exécutées sur CPU ou GPU selon les ressources disponibles."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Préparer l'environnement",
+        "",
+        "1. Créez et activez un environnement virtuel (optionnel mais recommandé).",
+        "2. Installez PhysAE et ses dépendances :",
+        "   ```bash",
+        "   pip install -e .[notebooks]",
+        "   ```",
+        "3. Si vous utilisez un GPU, installez la version de PyTorch compatible avec votre pilote CUDA. Consultez <https://pytorch.org/> pour la commande exacte.",
+        "",
+        "Ce carnet suppose que vous exécutez les commandes depuis la racine du dépôt PhysAE."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import torch",
+        "from pathlib import Path",
+        "from pprint import pprint",
+        "",
+        "from physae.factory import build_data_and_model",
+        "from physae.config_loader import load_data_config, load_stage_config, merge_dicts",
+        "from physae.training import train_stage_custom",
+        "",
+        "ROOT = Path.cwd().resolve()",
+        "CONFIG_DIR = ROOT / 'physae' / 'configs'",
+        "print(f'Utilisation des configurations à partir de {CONFIG_DIR}')",
+        "print(f'PyTorch détecte CUDA ? {torch.cuda.is_available()}')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Explorer les configurations YAML",
+        "",
+        "Les fichiers YAML définissent les plages de génération des données et les paramètres d'entraînement par défaut. Visualisons les éléments clés :"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "DATA_CONFIG = load_data_config(None, name='default')",
+        "print('Clés disponibles dans la configuration de données :')",
+        "print(sorted(DATA_CONFIG.keys()))",
+        "",
+        "STAGE_A = load_stage_config('A')",
+        "print('\\nParamètres principaux du stage A :')",
+        "pprint({k: STAGE_A[k] for k in ['epochs', 'base_lr', 'refiner_lr', 'delta_scale']})",
+        "",
+        "print('\\nEspace de recherche Optuna associé (non utilisé dans ce carnet) :')",
+        "pprint(STAGE_A.get('optuna', {}))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Construire jeux de données et modèle",
+        "",
+        "La fonction `build_data_and_model` assemble un modèle PhysAE et les loaders données en combinant la configuration YAML et vos surcharges. Nous définissons ci-dessous une fonction utilitaire qui réduit la taille des jeux pour des essais rapides, tout en laissant la possibilité de modifier chaque paramètre."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from dataclasses import dataclass",
+        "from typing import Dict, Any, Tuple",
+        "",
+        "@dataclass",
+        "class DemoSetup:",
+        "    model: Any",
+        "    loaders: Tuple[Any, Any]",
+        "    metadata: Dict[str, Any]",
+        "    stage_params: Dict[str, Any]",
+        "",
+        "",
+        "def build_demo_setup(",
+        "    *,",
+        "    stage: str = 'A',",
+        "    encoder_name: str = 'efficientnet',",
+        "    encoder_params: Dict[str, Any] | None = None,",
+        "    refiner_name: str | None = None,",
+        "    refiner_params: Dict[str, Any] | None = None,",
+        "    data_overrides: Dict[str, Any] | None = None,",
+        "    stage_overrides: Dict[str, Any] | None = None,",
+        "    seed: int = 1234,",
+        ") -> DemoSetup:",
+        "    \"\"\"Prépare un modèle PhysAE et ses loaders pour des essais rapides.\"\"\"",
+        "",
+        "    encoder_params = dict(encoder_params or {})",
+        "    refiner_name = refiner_name or encoder_name",
+        "    refiner_params = dict(refiner_params or {})",
+        "",
+        "    data_cfg_updates = {",
+        "        'n_train': 1024,",
+        "        'n_val': 256,",
+        "        'batch_size': 32,",
+        "        'seed': seed,",
+        "        'model': {",
+        "            'encoder': {",
+        "                'name': encoder_name,",
+        "                'params': encoder_params,",
+        "            },",
+        "            'refiner': {",
+        "                'name': refiner_name,",
+        "                'params': refiner_params,",
+        "            },",
+        "        },",
+        "    }",
+        "    if data_overrides:",
+        "        data_cfg_updates = merge_dicts(data_cfg_updates, data_overrides)",
+        "",
+        "    model, loaders, metadata = build_data_and_model(",
+        "        config_overrides=data_cfg_updates,",
+        "    )",
+        "",
+        "    stage_cfg = load_stage_config(stage)",
+        "    stage_cfg['epochs'] = min(stage_cfg.get('epochs', 10), 5)",
+        "    stage_cfg.setdefault('enable_progress_bar', True)",
+        "    if stage_overrides:",
+        "        stage_cfg = merge_dicts(stage_cfg, stage_overrides)",
+        "",
+        "    return DemoSetup(",
+        "        model=model,",
+        "        loaders=loaders,",
+        "        metadata=metadata,",
+        "        stage_params=stage_cfg,",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Choisir un backbone",
+        "",
+        "PhysAE propose quatre variantes principales. Le tableau suivant rappelle leurs caractéristiques et les contextes d'usage recommandés."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import pandas as pd",
+        "",
+        "backbones = [",
+        "    {'Backbone': 'efficientnet', 'Points forts': 'Rapide, robuste', 'Usage': 'Référence CPU/GPU'},",
+        "    {'Backbone': 'efficientnet_large', 'Points forts': 'Capacité accrue', 'Usage': 'Exploration GPU'},",
+        "    {'Backbone': 'efficientnet_v2', 'Points forts': 'Convergence rapide', 'Usage': 'Finetuning'},",
+        "    {'Backbone': 'convnext', 'Points forts': 'Performances élevées', 'Usage': 'Ressources GPU'},",
+        "]",
+        "",
+        "display(pd.DataFrame(backbones))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Lancer un entraînement minimal",
+        "",
+        "La fonction suivante entraîne un stage donné sur CPU ou GPU en affichant les métriques. Réglez `RUN_TRAINING = True` pour exécuter réellement l'entraînement. Les paramètres d'entrée permettent de modifier chaque étape : choix du backbone, du raffineur, des plages de données et des hyperparamètres de stage."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from typing import Optional",
+        "",
+        "RUN_TRAINING = False  # Passez à True pour lancer les entraînements",
+        "DEFAULT_ACCELERATOR = 'gpu' if torch.cuda.is_available() else 'cpu'",
+        "",
+        "",
+        "def run_training_demo(",
+        "    stage: str = 'A',",
+        "    *,",
+        "    encoder_name: str = 'efficientnet',",
+        "    encoder_params: Dict[str, Any] | None = None,",
+        "    refiner_name: Optional[str] = None,",
+        "    refiner_params: Dict[str, Any] | None = None,",
+        "    data_overrides: Dict[str, Any] | None = None,",
+        "    stage_overrides: Dict[str, Any] | None = None,",
+        "    accelerator: Optional[str] = None,",
+        ") -> None:",
+        "    setup = build_demo_setup(",
+        "        stage=stage,",
+        "        encoder_name=encoder_name,",
+        "        encoder_params=encoder_params,",
+        "        refiner_name=refiner_name,",
+        "        refiner_params=refiner_params,",
+        "        data_overrides=data_overrides,",
+        "        stage_overrides=stage_overrides,",
+        "    )",
+        "    train_loader, val_loader = setup.loaders",
+        "    params = dict(setup.stage_params)",
+        "    params['stage_name'] = stage",
+        "    params['accelerator'] = accelerator or DEFAULT_ACCELERATOR",
+        "    params.setdefault('trainer_kwargs', {})",
+        "    params['trainer_kwargs'].setdefault('log_every_n_steps', 5)",
+        "",
+        "    print('",
+        "Résumé des hyperparamètres :')",
+        "    pprint({k: params[k] for k in ('epochs', 'base_lr', 'refiner_lr', 'delta_scale')})",
+        "    print(f\"Accélérateur : {params['accelerator']}\")",
+        "    print(f\"Taille lot : {train_loader.batch_size}, steps/train : {len(train_loader)}\")",
+        "",
+        "    if RUN_TRAINING:",
+        "        _, metrics = train_stage_custom(",
+        "            setup.model,",
+        "            train_loader,",
+        "            val_loader,",
+        "            **params,",
+        "            return_metrics=True,",
+        "        )",
+        "        print('",
+        "Métriques de validation :')",
+        "        pprint(metrics)",
+        "    else:",
+        "        print('",
+        "Entraînement non lancé (RUN_TRAINING=False).')",
+        "        print('Activez RUN_TRAINING pour obtenir les métriques.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Exemple : EfficientNet sur CPU",
+        "",
+        "Ce scénario limite les échantillons et les époques pour un test rapide sur CPU."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "run_training_demo(",
+        "    stage='A',",
+        "    encoder_name='efficientnet',",
+        "    data_overrides={",
+        "        'n_train': 512,",
+        "        'n_val': 128,",
+        "        'batch_size': 16,",
+        "    },",
+        "    stage_overrides={",
+        "        'epochs': 3,",
+        "        'base_lr': 2e-4,",
+        "        'delta_scale': 0.12,",
+        "        'accelerator': 'cpu',",
+        "    },",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Exemple : ConvNeXt sur GPU",
+        "",
+        "Sur une machine équipée d'un GPU, augmentez légèrement la capacité et la durée d'entraînement."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "run_training_demo(",
+        "    stage='A',",
+        "    encoder_name='convnext',",
+        "    encoder_params={'width_mult': 0.75},",
+        "    data_overrides={",
+        "        'n_train': 2048,",
+        "        'n_val': 512,",
+        "        'batch_size': 32,",
+        "    },",
+        "    stage_overrides={",
+        "        'epochs': 6,",
+        "        'base_lr': 1.5e-4,",
+        "        'delta_scale': 0.1,",
+        "    },",
+        "    accelerator='gpu' if torch.cuda.is_available() else 'cpu',",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Boucle sur tous les backbones",
+        "",
+        "Utilisez la cellule ci-dessous pour générer automatiquement les configurations d'entraînement pour chaque backbone. Cela permet de comparer facilement les paramètres."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "for name in ['efficientnet', 'efficientnet_large', 'efficientnet_v2', 'convnext']:",
+        "    print(f\"\\n--- Préparation du backbone {name} ---\")",
+        "    run_training_demo(",
+        "        stage='A',",
+        "        encoder_name=name,",
+        "        stage_overrides={'epochs': 4},",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Ajuster les stages B1/B2 et le fine-tuning",
+        "",
+        "Après le stage A, enchaînez avec les stages B1 et B2 pour raffiner le modèle. Utilisez le paramètre `ckpt_in` pour charger un checkpoint précédent, ou `ckpt_out` pour sauvegarder le modèle entraîné :"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "run_training_demo(",
+        "    stage='B1',",
+        "    stage_overrides={",
+        "        'epochs': 4,",
+        "        'train_refiner': True,",
+        "        'train_base': False,",
+        "        'refine_steps': 2,",
+        "        'ckpt_in': 'path/vers/stage_A.ckpt',  # Remplacez par votre checkpoint",
+        "        'ckpt_out': 'artifacts/stage_B1.ckpt',",
+        "    },",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Bonnes pratiques",
+        "",
+        "* **Stabilité** : commencez avec des tailles de lot réduites et augmentez-les progressivement.",
+        "* **CPU vs GPU** : laissez `accelerator=None` pour l'auto-détection ; forcez `\"cpu\"` pour déboguer.",
+        "* **Normalisation** : si vous modifiez les plages d'échantillonnage, vérifiez que les valeurs restent compatibles avec `config.NORM_PARAMS`.",
+        "* **Suivi des expériences** : stockez les sorties (checkpoints, métriques) dans un dossier dédié par run.",
+        "* **Extensions** : ajoutez vos backbones via `physae.models.register_encoder` et passez le nom dans la section `model.encoder`."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/notebooks/09_optuna_workflow.ipynb
+++ b/notebooks/09_optuna_workflow.ipynb
@@ -1,0 +1,294 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Optimisation Optuna des stages PhysAE",
+        "",
+        "Ce carnet détaille comment explorer et optimiser les stages A, B et la chaîne complète A→B1→B2 avec Optuna. Il fournit des bonnes pratiques pour ajuster les espaces de recherche et automatiser le fine-tuning."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Préparer l'environnement",
+        "",
+        "1. Vérifiez que PhysAE est installé avec le support Optuna :",
+        "   ```bash",
+        "   pip install -e .[optuna]",
+        "   ```",
+        "2. Activez un serveur d'exécution capable de supporter les essais (CPU ou GPU).",
+        "3. Créez un répertoire pour stocker les artefacts Optuna (`studies/` par exemple)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from pathlib import Path",
+        "from pprint import pprint",
+        "",
+        "import torch",
+        "",
+        "from physae.config_loader import load_stage_config",
+        "from physae.optimization import optimise_stage",
+        "",
+        "ROOT = Path.cwd().resolve()",
+        "ARTIFACTS = ROOT / 'studies'",
+        "ARTIFACTS.mkdir(exist_ok=True)",
+        "print(f'Les résultats Optuna seront enregistrés dans {ARTIFACTS.resolve()}')",
+        "print(f'CUDA disponible ? {torch.cuda.is_available()}')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Inspecter les espaces de recherche",
+        "",
+        "Chaque stage possède une section `optuna` dans son fichier YAML. Affichons les paramètres explorés pour les stages A, B1 et B2."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "for stage in ['A', 'B1', 'B2']:",
+        "    cfg = load_stage_config(stage)",
+        "    search_space = cfg.get('optuna', {})",
+        "    print(f\"",
+        "=== Stage {stage} : {len(search_space)} paramètres ===\")",
+        "    for name, spec in search_space.items():",
+        "        pprint({name: spec})"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Fonction utilitaire pour lancer une optimisation",
+        "",
+        "Le helper ci-dessous centralise les options d'exécution (nombre d'essais, overrides de données ou de stage, accélérateur). Réglez `RUN_OPTUNA = True` pour démarrer une étude complète."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "RUN_OPTUNA = False",
+        "DEFAULT_ACCELERATOR = 'gpu' if torch.cuda.is_available() else 'cpu'",
+        "",
+        "",
+        "def run_optuna_demo(",
+        "    stage: str,",
+        "    *,",
+        "    n_trials: int = 10,",
+        "    metric: str = 'val_loss',",
+        "    direction: str = 'minimize',",
+        "    data_overrides=None,",
+        "    stage_overrides=None,",
+        "    accelerator: str | None = None,",
+        "    study_suffix: str | None = None,",
+        "):",
+        "    'Lance une étude Optuna sur un stage PhysAE.'",
+        "",
+        "    accelerator = accelerator or DEFAULT_ACCELERATOR",
+        "    study_name = f\"physae-stage-{stage.lower()}\"",
+        "    if study_suffix:",
+        "        study_name = f\"{study_name}-{study_suffix}\"",
+        "",
+        "    print(f\"Stage : {stage}",
+        "Essais : {n_trials}",
+        "Accélérateur ciblé : {accelerator}\")",
+        "    print(f\"Overrides données : {data_overrides}\")",
+        "    print(f\"Overrides stage : {stage_overrides}\")",
+        "    print(f\"Nom d'étude Optuna : {study_name}\")",
+        "",
+        "    if not RUN_OPTUNA:",
+        "        print('",
+        "Exécution simulée. Passez RUN_OPTUNA=True pour lancer l'optimisation.",
+        "')",
+        "        return None",
+        "",
+        "    study = optimise_stage(",
+        "        stage,",
+        "        n_trials=n_trials,",
+        "        metric=metric,",
+        "        direction=direction,",
+        "        data_overrides=data_overrides,",
+        "        stage_overrides=stage_overrides,",
+        "        output_dir=str(ARTIFACTS),",
+        "        show_progress_bar=True,",
+        "    )",
+        "    print(f\"",
+        "Meilleur score : {study.best_value}\")",
+        "    print('Paramètres optimaux :')",
+        "    pprint(study.best_params)",
+        "    return study"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Optimiser le stage A",
+        "",
+        "Commencez par réduire la taille des données pour accélérer les essais, puis augmentez progressivement `n_trials`. Ajustez `data_overrides` pour contrôler le bruit, les tailles d'échantillons et les plages de génération."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "run_optuna_demo(",
+        "    'A',",
+        "    n_trials=8,",
+        "    data_overrides={",
+        "        'n_train': 2048,",
+        "        'n_val': 512,",
+        "        'batch_size': 32,",
+        "    },",
+        "    stage_overrides={",
+        "        'epochs': 8,",
+        "        'enable_progress_bar': True,",
+        "    },",
+        "    study_suffix='quickstart',",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Optimiser le stage B (raffinement)",
+        "",
+        "Le stage B1 fige le backbone et se concentre sur le raffineur. Ajustez les paramètres `refine_steps`, `delta_scale` et `refiner_lr`. Les overrides peuvent inclure un checkpoint issu du stage A pour initialiser le modèle."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "run_optuna_demo(",
+        "    'B1',",
+        "    n_trials=6,",
+        "    data_overrides={",
+        "        'n_train': 1024,",
+        "        'n_val': 256,",
+        "    },",
+        "    stage_overrides={",
+        "        'epochs': 6,",
+        "        'ckpt_in': 'artifacts/stage_A.ckpt',",
+        "        'accelerator': DEFAULT_ACCELERATOR,",
+        "    },",
+        "    study_suffix='b1-refiner',",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Chaîne complète A + B1 + B2 et fine-tuning",
+        "",
+        "Ce scénario illustre comment enchaîner plusieurs études :",
+        "1. Optimisez A et récupérez les meilleurs hyperparamètres.",
+        "2. Lancez B1 avec le checkpoint A optimal.",
+        "3. Finalisez avec B2 en réactivant le backbone et le module FiLM.",
+        "",
+        "Les deux blocs de code suivants montrent comment charger les meilleurs résultats d'une étude précédente et comment configurer une session finale de fine-tuning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from pathlib import Path",
+        "import json",
+        "",
+        "",
+        "def charger_params_optuna(stage: str, suffix: str):",
+        "    'Charge les paramètres Optuna sauvegardés pour un stage donné.'",
+        "    directory = ARTIFACTS / f'stage_{stage.upper()}'",
+        "    if suffix:",
+        "        directory = ARTIFACTS / f'stage_{stage.upper()}-{suffix}'",
+        "    summary_path = directory / 'summary.json'",
+        "    if not summary_path.exists():",
+        "        print(f\"Aucun résumé trouvé pour {summary_path}\")",
+        "        return None",
+        "    with open(summary_path, 'r', encoding='utf-8') as fh:",
+        "        return json.load(fh)",
+        "",
+        "best_A = charger_params_optuna('A', 'quickstart')",
+        "if best_A:",
+        "    print('Meilleurs hyperparamètres stage A :')",
+        "    pprint(best_A['best_params'])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "run_optuna_demo(",
+        "    'B2',",
+        "    n_trials=4,",
+        "    data_overrides={",
+        "        'n_train': 2048,",
+        "        'n_val': 512,",
+        "    },",
+        "    stage_overrides={",
+        "        'epochs': 8,",
+        "        'ckpt_in': 'artifacts/stage_B1.ckpt',",
+        "        'train_base': True,",
+        "        'train_heads': True,",
+        "        'train_film': True,",
+        "        'enable_progress_bar': True,",
+        "    },",
+        "    study_suffix='b2-finetune',",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Bonnes pratiques pour Optuna",
+        "",
+        "* **Budget** : démarrez avec peu d'essais (`n_trials=3`) pour valider le pipeline puis augmentez.",
+        "* **Reproductibilité** : fixez `seed` dans `data_overrides` et utilisez un stockage Optuna (SQLite, PostgreSQL) pour reprendre les études.",
+        "* **Accélérateur** : forcez `accelerator='cpu'` pour déboguer ; sur GPU, surveillez la mémoire avec `nvidia-smi`.",
+        "* **Export** : exploitez les fichiers `summary.json`, `best_stage_params.yaml` et `trials.csv` générés automatiquement.",
+        "* **Coordination des stages** : alignez les plages de recherche entre A et B pour éviter des combinaisons incohérentes (par exemple `width_mult`)."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a hands-on training workflow notebook that demonstrates configuring each backbone, adjusting stage parameters, and chaining stages
- add an Optuna-focused notebook covering stage A, B, and combined A→B1→B2 optimisation with reusable helpers and best practices

## Testing
- not run (notebook-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d830e6c61c832aad6e27feb6e1ddbc