### PR TITLE
Add data construction notebook with adjusted validation ranges

### DIFF
--- a/notebooks/data_construction.ipynb
+++ b/notebooks/data_construction.ipynb
@@ -1,0 +1,109 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Custom dataset construction\n",
+        "This notebook narrows the training ranges and adjusts validation ranges to remain nested."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "from copy import deepcopy\n",
+        "from physae.config_loader import load_data_config\n",
+        "from physae import config as physae_config"
+      ],
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "custom_cfg = load_data_config(name=\"default\")\n",
+        "narrow_train_ranges = {\n",
+        "    \"sig0\": [3085.435, 3085.447],\n",
+        "    \"dsig\": [0.0015235, 0.0015335],\n",
+        "    \"mf_CH4\": [5.0e-06, 1.4e-05],\n",
+        "    \"baseline0\": [0.995, 1.005],\n",
+        "    \"baseline1\": [-0.00038, -0.00031],\n",
+        "    \"baseline2\": [-3.8e-08, -3.2e-08],\n",
+        "    \"P\": [450.0, 550.0],\n",
+        "    \"T\": [305.0, 309.0],\n",
+        "}\n",
+        "custom_cfg[\"train_ranges\"] = {name: [float(v[0]), float(v[1])] for name, v in narrow_train_ranges.items()}\n",
+        "original_val_ranges = deepcopy(custom_cfg.get(\"val_ranges\", {}))\n",
+        "adjusted_val_ranges = {}\n",
+        "for name, train_interval in custom_cfg[\"train_ranges\"].items():\n",
+        "    train_min, train_max = map(float, train_interval)\n",
+        "    val_min, val_max = map(float, original_val_ranges.get(name, train_interval))\n",
+        "    adj_min = max(val_min, train_min)\n",
+        "    adj_max = min(val_max, train_max)\n",
+        "    if adj_min > adj_max:\n",
+        "        centre = 0.5 * (train_min + train_max)\n",
+        "        adj_min = adj_max = centre\n",
+        "    adjusted_val_ranges[name] = [adj_min, adj_max]\n",
+        "custom_cfg[\"val_ranges\"] = adjusted_val_ranges\n",
+        "physae_config.set_norm_params({name: (float(r[0]), float(r[1])) for name, r in custom_cfg[\"train_ranges\"].items()})\n",
+        "custom_cfg[\"val_ranges\"]\n"
+      ],
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": [
+        "from physae.dataset import SpectraDataset\n",
+        "from physae.physics import parse_csv_transitions\n\n",
+        "poly_freq_CH4 = [-2.3614803e-07, 1.2103413e-10, -3.1617856e-14]\n",
+        "transitions_ch4_str = \"\"\"6;1;3085.861015;1.013E-19;0.06;0.078;219.9411;0.73;-0.00712;0.0;0.0221;0.96;0.584;1.12\\n6;1;3085.832038;1.693E-19;0.0597;0.078;219.9451;0.73;-0.00712;0.0;0.0222;0.91;0.173;1.11\\n6;1;3085.893769;1.011E-19;0.0602;0.078;219.9366;0.73;-0.00711;0.0;0.0184;1.14;-0.516;1.37\\n6;1;3086.030985;1.659E-19;0.0595;0.078;219.9197;0.73;-0.00711;0.0;0.0193;1.17;-0.204;0.97\\n6;1;3086.071879;1.000E-19;0.0585;0.078;219.9149;0.73;-0.00703;0.0;0.0232;1.09;-0.0689;0.82\\n6;1;3086.085994;6.671E-20;0.055;0.078;219.9133;0.70;-0.00610;0.0;0.0300;0.54;0.00;0.0\"\"\"\n",
+        "transitions_dict = {\"CH4\": parse_csv_transitions(transitions_ch4_str)}\n\n",
+        "train_dataset = SpectraDataset(\n",
+        "    n_samples=16,\n",
+        "    num_points=800,\n",
+        "    poly_freq_CH4=poly_freq_CH4,\n",
+        "    transitions_dict=transitions_dict,\n",
+        "    sample_ranges={name: (float(r[0]), float(r[1])) for name, r in custom_cfg[\"train_ranges\"].items()},\n",
+        "    strict_check=True,\n",
+        "    with_noise=False,\n",
+        ")\n",
+        "val_dataset = SpectraDataset(\n",
+        "    n_samples=8,\n",
+        "    num_points=800,\n",
+        "    poly_freq_CH4=poly_freq_CH4,\n",
+        "    transitions_dict=transitions_dict,\n",
+        "    sample_ranges={name: (float(r[0]), float(r[1])) for name, r in custom_cfg[\"val_ranges\"].items()},\n",
+        "    strict_check=True,\n",
+        "    with_noise=False,\n",
+        ")\n",
+        "print(\"Train dataset mf_CH4 range:\", train_dataset.sample_ranges[\"mf_CH4\"])\n",
+        "print(\"Validation dataset mf_CH4 range:\", val_dataset.sample_ranges[\"mf_CH4\"])\n",
+        "print(\"Validation ranges \u2286 training ranges?\",\n",
+        "      all(\n",
+        "          train_dataset.sample_ranges[name][0] <= val_dataset.sample_ranges[name][0]\n",
+        "          and val_dataset.sample_ranges[name][1] <= train_dataset.sample_ranges[name][1]\n",
+        "          for name in val_dataset.sample_ranges\n",
+        "      ))"
+      ],
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a `data_construction` notebook that narrows the training configuration for experimentation
- clone and tighten validation ranges after overriding `train_ranges` so every interval stays inside the training domain
- document dataset instantiation that relies on the adjusted ranges to satisfy the strict subset check

## Testing
- not run (PyTorch unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d83faabd08832a9f356da8d5a40354