### PR TITLE
Handle missing refiner when toggling FiLM usage

### DIFF
--- a/physae
+++ b/physae
@@ -884,8 +884,9 @@ class PhysicallyInformedAE(pl.LightningModule):
     # ========= helpers / FiLM / stage control =========
     def set_film_usage(self, use: bool = True):
         self.use_film = bool(use)
-        if hasattr(self, "refiner"):
-            self.refiner.use_film = bool(use)
+        refiner = getattr(self, "refiner", None)
+        if refiner is not None:
+            refiner.use_film = bool(use)
 
     def set_film_subset(self, names=None):
         if self.cond_dim == 0 or self.film_mask is None:


### PR DESCRIPTION
## Summary
- guard calls that toggle the refiner FiLM flag when no refiner module is instantiated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da91077040832a9e73b66635d72d84