### PR TITLE
Streamline trial checkpoint handling

### DIFF
--- a/physae
+++ b/physae
@@ -2365,9 +2365,12 @@ def make_run_dir(base="runs"):
         (Path(existing) / "finetune" / "figs").mkdir(parents=True, exist_ok=True)
         return existing
 
-    job = os.environ.get("SLURM_JOB_ID", "local")
-    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    run_dir = Path(base) / f"study_{job}_{stamp}"
+    job = os.environ.get("SLURM_JOB_ID")
+    if job:
+        run_dir = Path(base) / f"study_{job}"
+    else:
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        run_dir = Path(base) / f"study_local_{stamp}"
     run_dir.mkdir(parents=True, exist_ok=True)
 
     for stage in ("A", "B"):
@@ -2660,6 +2663,42 @@ def _atomic_update_best_ckpt(
                 pass
 
 
+def _cleanup_trial_checkpoint(path: Union[str, Path]):
+    if not path:
+        return
+
+    p = Path(path)
+    try:
+        if p.exists():
+            p.unlink()
+    except Exception:
+        pass
+
+    parent = p.parent
+    try:
+        if parent.exists() and not any(parent.iterdir()):
+            parent.rmdir()
+    except Exception:
+        pass
+
+
+def _register_trial_best(stage_dir: Path, stage_name: str, best_path: Optional[str], best_score: float,
+                         direction: str = "min") -> str:
+    if not best_path:
+        return ""
+
+    dest_ckpt = stage_dir / "checkpoints" / f"{stage_name}_optuna_best.ckpt"
+    meta_path = stage_dir / "checkpoints" / f"{stage_name}_optuna_best.json"
+    is_new_best, final_ckpt = _atomic_update_best_ckpt(best_path, best_score, dest_ckpt, meta_path, direction=direction)
+
+    _cleanup_trial_checkpoint(best_path)
+
+    if final_ckpt and os.path.isfile(final_ckpt):
+        return final_ckpt
+
+    return ""
+
+
 def _trial_dirs(run_dir: Path, stage: str, trial_number: int) -> dict[str, Path]:
     stage_dir = get_stage_dir(run_dir, stage)
     root = stage_dir / "trials" / f"trial_{trial_number:04d}"
@@ -2671,7 +2710,10 @@ def _trial_dirs(run_dir: Path, stage: str, trial_number: int) -> dict[str, Path]
 
 
 def _common_callbacks(stage: str, val_loader, fig_dir: Path, monitor: str = "val_loss",
-                      patience: int = 15) -> list:
+                      patience: int = 15, ckpt_dir: Optional[Path] = None) -> list:
+    if ckpt_dir is not None:
+        ckpt_dir = Path(ckpt_dir)
+        ckpt_dir.mkdir(parents=True, exist_ok=True)
     ckp = ModelCheckpoint(
         monitor=monitor,
         mode="min",
@@ -2679,6 +2721,7 @@ def _common_callbacks(stage: str, val_loader, fig_dir: Path, monitor: str = "val
         filename=f"best-{stage}",
         save_last=False,
         auto_insert_metric_name=False,
+        dirpath=str(ckpt_dir) if ckpt_dir is not None else None,
     )
     early = EarlyStopping(monitor=monitor, mode="min", patience=patience)
     plot = PlotAndMetricsCallback(val_loader, PARAMS, num_examples=1, save_dir=str(fig_dir), stage_tag=f"stage_{stage}")
@@ -2717,6 +2760,7 @@ def objective_stage_A(trial: optuna.Trial, *, run_dir: Path, epochs: int, seed: 
     batch_size          = trial.suggest_categorical("batch_size", [8, 12, 16, 24, 32])
 
     # Dossiers dédiés au trial
+    stage_dir = get_stage_dir(run_dir, "A")
     dirs = _trial_dirs(run_dir, stage="A", trial_number=trial.number)
 
     # Construire data + modèle avec HPs trial
@@ -2737,7 +2781,7 @@ def objective_stage_A(trial: optuna.Trial, *, run_dir: Path, epochs: int, seed: 
     tkw["default_root_dir"] = str(dirs["root"] / "logs")
 
     # Callbacks
-    callbacks = _common_callbacks("A", val_loader, fig_dir=dirs["figs"], patience=12)
+    callbacks = _common_callbacks("A", val_loader, fig_dir=dirs["figs"], patience=12, ckpt_dir=dirs["ckpts"])
     callbacks = [LossHistory(trial), *callbacks] 
     # Lancement stage A
     train_stage_A(
@@ -2752,10 +2796,9 @@ def objective_stage_A(trial: optuna.Trial, *, run_dir: Path, epochs: int, seed: 
     # Récup meilleure val_loss + ckpt
     # Récup meilleure val_loss + ckpt
     best_score, best_path = _score_from_callbacks(callbacks)
+    global_ckpt = _register_trial_best(stage_dir, "A", best_path, best_score, direction="min")
 
-    # ➜ MAJ best global + nettoyage
-# ➜ on laisse run_optuna_stage_A faire l’update atomique global
-    trial.set_user_attr("best_ckpt_A", best_path or "")
+    trial.set_user_attr("best_ckpt_A", global_ckpt)
     trial.set_user_attr("best_val_A", best_score)
     return best_score
 
@@ -2778,7 +2821,8 @@ def objective_stage_B1(trial: optuna.Trial, *, run_dir: Path, epochs: int, seed:
 
     batch_size = trial.suggest_categorical("batch_size", [8, 12, 16, 24, 32])
 
-    dirs = _trial_dirs(run_dir, stage="B1", trial_number=trial.number)
+    stage_dir = get_stage_dir(run_dir, "B")
+    dirs = _trial_dirs(run_dir, stage="B", trial_number=trial.number)
 
     # IMPORTANT: reconstruit le modèle avec les HP refiner (le backbone peut rester celui du meilleur A)
     model, train_loader, val_loader = build_data_and_model(
@@ -2797,7 +2841,7 @@ def objective_stage_B1(trial: optuna.Trial, *, run_dir: Path, epochs: int, seed:
     tkw["devices"] = 1
     tkw["default_root_dir"] = str(dirs["root"] / "logs")
 
-    callbacks = _common_callbacks("B1", val_loader, fig_dir=dirs["figs"], patience=10)
+    callbacks = _common_callbacks("B1", val_loader, fig_dir=dirs["figs"], patience=10, ckpt_dir=dirs["ckpts"])
     callbacks = [LossHistory(trial), *callbacks] 
 
 
@@ -2815,8 +2859,9 @@ def objective_stage_B1(trial: optuna.Trial, *, run_dir: Path, epochs: int, seed:
 
     # Récup meilleure val_loss + ckpt
     best_score, best_path = _score_from_callbacks(callbacks)
+    global_ckpt = _register_trial_best(stage_dir, "B1", best_path, best_score, direction="min")
 
-    trial.set_user_attr("best_ckpt_B1", best_path or "")
+    trial.set_user_attr("best_ckpt_B1", global_ckpt)
     trial.set_user_attr("best_val_B1", best_score)
     return best_score
 
@@ -2919,7 +2964,8 @@ def retrain_stage_A(best_params: dict, *, epochs: int, seed: int, n_train: int =
     retrain_dir = stage_dir / "retrain"
     logs_dir = retrain_dir / "logs"
     figs_dir = retrain_dir / "figs"
-    for p in (logs_dir, figs_dir):
+    ckpts_dir = retrain_dir / "ckpts"
+    for p in (logs_dir, figs_dir, ckpts_dir):
         p.mkdir(parents=True, exist_ok=True)
 
     batch_size = int(best_params.get("batch_size", 16))
@@ -2938,7 +2984,7 @@ def retrain_stage_A(best_params: dict, *, epochs: int, seed: int, n_train: int =
     tkw = trainer_common_kwargs()
     tkw["default_root_dir"] = str(logs_dir)
 
-    callbacks = _common_callbacks("A_retrain", val_loader, fig_dir=figs_dir, patience=15)
+    callbacks = _common_callbacks("A_retrain", val_loader, fig_dir=figs_dir, patience=15, ckpt_dir=ckpts_dir)
     ckpt_last = retrain_dir / "last.ckpt"
 
     train_stage_A(
@@ -2975,7 +3021,8 @@ def retrain_stage_B(best_params: dict, stage_a_params: dict, stage_a_ckpt: str, 
     retrain_dir = stage_dir / "retrain"
     logs_dir = retrain_dir / "logs"
     figs_dir = retrain_dir / "figs"
-    for p in (logs_dir, figs_dir):
+    ckpts_dir = retrain_dir / "ckpts"
+    for p in (logs_dir, figs_dir, ckpts_dir):
         p.mkdir(parents=True, exist_ok=True)
 
     batch_size = int(best_params.get("batch_size", stage_a_params.get("batch_size", 16)))
@@ -3000,7 +3047,7 @@ def retrain_stage_B(best_params: dict, stage_a_params: dict, stage_a_ckpt: str, 
     tkw = trainer_common_kwargs()
     tkw["default_root_dir"] = str(logs_dir)
 
-    callbacks = _common_callbacks("B_retrain", val_loader, fig_dir=figs_dir, patience=12)
+    callbacks = _common_callbacks("B_retrain", val_loader, fig_dir=figs_dir, patience=12, ckpt_dir=ckpts_dir)
     ckpt_last = retrain_dir / "last.ckpt"
 
     train_stage_B1(
@@ -3040,6 +3087,7 @@ def finetune_ensemble(ckpt_B_path: str, best_a_params: dict, best_b_params: dict
     finetune_dir = Path(run_dir) / "finetune"
     logs_dir = finetune_dir / "logs"
     figs_dir = finetune_dir / "figs"
+    tmp_ckpt_dir = finetune_dir / "tmp_ckpts"
     for p in (logs_dir, figs_dir):
         p.mkdir(parents=True, exist_ok=True)
 
@@ -3065,7 +3113,9 @@ def finetune_ensemble(ckpt_B_path: str, best_a_params: dict, best_b_params: dict
     tkw = trainer_common_kwargs()
     tkw["default_root_dir"] = str(logs_dir)
 
-    callbacks = _common_callbacks("B2_finetune", val_loader, fig_dir=figs_dir, patience=10)
+    tmp_ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    callbacks = _common_callbacks("B2_finetune", val_loader, fig_dir=figs_dir, patience=10, ckpt_dir=tmp_ckpt_dir)
     ckpt_last = finetune_dir / "checkpoints" / "finetune_last.ckpt"
 
     train_stage_B2(
@@ -3112,8 +3162,11 @@ def optional_finetune_B2(ckpt_B1_path: str, epochs: int = 20):
     ft_dir = Path(run_dir) / "finetune"
     tkw["default_root_dir"] = str(ft_dir / "logs")
 
+    tmp_ckpt_dir = ft_dir / "tmp_ckpts"
+    tmp_ckpt_dir.mkdir(parents=True, exist_ok=True)
+
     out_path = ft_dir / "checkpoints" / "B2_optional.ckpt"
-    callbacks = _common_callbacks("B2_optional", val_loader, fig_dir=ft_dir / "figs", patience=8)
+    callbacks = _common_callbacks("B2_optional", val_loader, fig_dir=ft_dir / "figs", patience=8, ckpt_dir=tmp_ckpt_dir)
 
     train_stage_B2(
         model, train_loader, val_loader,


### PR DESCRIPTION
## Summary
- keep only the global best checkpoint for each Optuna trial by copying it to a shared location and deleting per-trial artifacts
- point stage B1 trials at the main B run directory and route callbacks to dedicated checkpoint folders
- reuse a single run directory per SLURM job to avoid duplicate job folders

## Testing
- python -m compileall physae

------
https://chatgpt.com/codex/tasks/task_e_68e12fd6a188832a97fdafcec21f4fa4