### PR TITLE
Enable configuring Optuna trials and dataset sizes from SLURM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # physae
+
+## Lancement des entraînements Optuna
+
+Le script SLURM `soumission.txt` permet désormais de paramétrer depuis la ligne de
+commande le nombre de trials, le nombre d'epochs et les tailles des jeux de
+données synthétiques pour chaque étape.
+
+Exemple d'appel avec `sbatch` :
+
+```bash
+sbatch soumission.txt \
+  --trials-a 150 \
+  --trials-b 120 \
+  --epochs-a 40 \
+  --epochs-b 30 \
+  --train-samples 200000 \
+  --val-samples 1000 \
+  --retrain-samples 1500000
+```
+
+Utilisez `sbatch soumission.txt --help` pour afficher la liste complète des
+options disponibles et leurs valeurs par défaut.

--- a/soumission.txt
+++ b/soumission.txt
@@ -11,6 +11,72 @@
 #SBATCH --output=job_ptl_%J.out
 #SBATCH --error=job_ptl_%J.err
 
+set -euo pipefail
+
+show_help() {
+  cat <<'USAGE'
+Usage: sbatch soumission.txt [options]
+
+Options:
+  --trials-a <int>         Nombre d'essais Optuna pour le stage A (défaut: 200)
+  --trials-b <int>         Nombre d'essais Optuna pour le stage B1 (défaut: 200)
+  --epochs-a <int>         Nombre d'epochs par essai pour le stage A (défaut: 50)
+  --epochs-b <int>         Nombre d'epochs par essai pour le stage B1 (défaut: 50)
+  --train-samples <int>    Taille du dataset synthétique d'entraînement (défaut: 100000)
+  --val-samples <int>      Taille du dataset synthétique de validation (défaut: 500)
+  --retrain-samples <int>  Taille du dataset synthétique pour les ré-entraînements finaux (défaut: 1000000)
+  -h, --help               Affiche cette aide
+USAGE
+}
+
+TRIALS_A=200
+TRIALS_B=200
+EPOCHS_A=50
+EPOCHS_B=50
+TRAIN_SAMPLES=100000
+VAL_SAMPLES=500
+RETRAIN_SAMPLES=1000000
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --trials-a)
+      TRIALS_A="$2"; shift 2 ;;
+    --trials-a=*)
+      TRIALS_A="${1#*=}"; shift ;;
+    --trials-b)
+      TRIALS_B="$2"; shift 2 ;;
+    --trials-b=*)
+      TRIALS_B="${1#*=}"; shift ;;
+    --epochs-a)
+      EPOCHS_A="$2"; shift 2 ;;
+    --epochs-a=*)
+      EPOCHS_A="${1#*=}"; shift ;;
+    --epochs-b)
+      EPOCHS_B="$2"; shift 2 ;;
+    --epochs-b=*)
+      EPOCHS_B="${1#*=}"; shift ;;
+    --train-samples)
+      TRAIN_SAMPLES="$2"; shift 2 ;;
+    --train-samples=*)
+      TRAIN_SAMPLES="${1#*=}"; shift ;;
+    --val-samples)
+      VAL_SAMPLES="$2"; shift 2 ;;
+    --val-samples=*)
+      VAL_SAMPLES="${1#*=}"; shift ;;
+    --retrain-samples)
+      RETRAIN_SAMPLES="$2"; shift 2 ;;
+    --retrain-samples=*)
+      RETRAIN_SAMPLES="${1#*=}"; shift ;;
+    -h|--help)
+      show_help
+      exit 0 ;;
+    *)
+      echo "Unknown option: $1" >&2
+      show_help >&2
+      exit 1 ;;
+  esac
+done
+
 # --- Environnement logiciel
 romeo_load_armgpu_env
 spack load python@3.13.0/gzl2pkh cuda@12.6.2
@@ -20,5 +86,25 @@ source /home/cosmic_86/envs/pytorch_arm_test/bin/activate
 export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 export MKL_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
+PYTHON_SCRIPT="/home/cosmic_86/CODES/scripts/10_PIAE_trainv2_effv2_opt.py"
+
+cat <<EOM
+Lancement du script ${PYTHON_SCRIPT} avec les paramètres :
+  trials A       : ${TRIALS_A}
+  trials B1      : ${TRIALS_B}
+  epochs A       : ${EPOCHS_A}
+  epochs B1      : ${EPOCHS_B}
+  train samples  : ${TRAIN_SAMPLES}
+  val samples    : ${VAL_SAMPLES}
+  retrain samples: ${RETRAIN_SAMPLES}
+EOM
+
 srun --cpu-bind=cores \
-     python -u /home/cosmic_86/CODES/scripts/10_PIAE_trainv2_effv2_opt.py
+     python -u "${PYTHON_SCRIPT}" \
+        --trials-a "${TRIALS_A}" \
+        --trials-b "${TRIALS_B}" \
+        --epochs-a "${EPOCHS_A}" \
+        --epochs-b "${EPOCHS_B}" \
+        --train-samples "${TRAIN_SAMPLES}" \
+        --val-samples "${VAL_SAMPLES}" \
+        --retrain-samples "${RETRAIN_SAMPLES}"


### PR DESCRIPTION
## Summary
- add CLI parsing in `soumission.txt` so sbatch callers can override trials, epochs, and dataset sizes
- document the new usage pattern and defaults in the README

## Testing
- not run (infrastructure script changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e13d930530832aa14ba5c5b771b571