### PR TITLE
Align submission script with local trainer

### DIFF
--- a/soumission.txt
+++ b/soumission.txt
@@ -97,7 +97,7 @@ export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 export MKL_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PYTHON_SCRIPT="/home/cosmic_86/CODES/scripts/10_PIAE_trainv2_effv2_opt.py"
+PYTHON_SCRIPT="${SCRIPT_DIR}/physae.py"
 cat <<EOM
 Lancement du script ${PYTHON_SCRIPT} avec les paramètres :
   trials A       : ${TRIALS_A}


### PR DESCRIPTION
## Summary
- point submission script at the repository's physae.py entry point

## Testing
- python -m compileall physae.py

------
https://chatgpt.com/codex/tasks/task_e_68e20b4c6438832aa12a5f359d2c9450