### PR TITLE
Add YAML configs for dataset parameters, noise, and transitions

### DIFF
--- a/project/config/data/noise_default.yaml
+++ b/project/config/data/noise_default.yaml
@@ -1,0 +1,16 @@
+# Configuration du profil de bruit utilisé pendant la génération des spectres synthétiques.
+noise:
+  std_add_range: [0.001, 0.01]
+  std_mult_range: [0.002, 0.02]
+  p_drift: 0.7
+  drift_sigma_range: [8.0, 90.0]
+  drift_amp_range: [0.002, 0.03]
+  p_fringes: 0.6
+  n_fringes_range: [1, 3]
+  fringe_freq_range: [0.2, 12.0]
+  fringe_amp_range: [0.001, 0.01]
+  p_spikes: 0.4
+  spikes_count_range: [1, 4]
+  spike_amp_range: [0.002, 0.03]
+  spike_width_range: [1.0, 4.0]
+  clip: [0.0, 1.3]

--- a/project/config/data/parameters_default.yaml
+++ b/project/config/data/parameters_default.yaml
@@ -1,0 +1,36 @@
+# Default parameter ranges for synthetic spectra generation.
+# Each entry defines the minimum and maximum value sampled during dataset creation.
+parameters:
+  sig0:
+    min: 5995.0
+    max: 6005.0
+    description: Centre de la grille spectrale (cm^-1)
+  dsig:
+    min: 8.0
+    max: 12.0
+    description: Largeur spectrale balayée (cm^-1)
+  mf_CH4:
+    min: 1.0e-6
+    max: 5.0e-3
+    log_scale: true
+    description: Fraction molaire de CH4
+  baseline0:
+    min: 0.8
+    max: 1.2
+    description: Terme constant de la ligne de base
+  baseline1:
+    min: -0.02
+    max: 0.02
+    description: Terme linéaire de la ligne de base
+  baseline2:
+    min: -0.001
+    max: 0.001
+    description: Terme quadratique de la ligne de base
+  P:
+    min: 0.5
+    max: 1.2
+    description: Pression totale (atm)
+  T:
+    min: 250.0
+    max: 320.0
+    description: Température (K)

--- a/project/config/data/transitions_sample.yaml
+++ b/project/config/data/transitions_sample.yaml
@@ -1,0 +1,47 @@
+# Exemple de transitions spectroscopiques réduites pour CH4 et H2O.
+# Les valeurs sont synthétiques et servent de gabarit pour préparer vos propres fichiers.
+transitions:
+  CH4:
+    - mid: 6
+      lid: 1
+      center: 5998.1234
+      amplitude: 1.20e-20
+      gamma_air: 0.070
+      gamma_self: 0.090
+      e0: 120.5
+      n_air: 0.75
+      shift_air: -0.005
+      abundance: 0.999
+      gDicke: 0.015
+      nDicke: 0.25
+      lmf: 0.010
+      nlmf: 0.70
+    - mid: 6
+      lid: 2
+      center: 6001.8765
+      amplitude: 8.50e-21
+      gamma_air: 0.066
+      gamma_self: 0.085
+      e0: 98.1
+      n_air: 0.74
+      shift_air: -0.004
+      abundance: 0.999
+      gDicke: 0.012
+      nDicke: 0.22
+      lmf: -0.008
+      nlmf: 0.65
+  H2O:
+    - mid: 1
+      lid: 1
+      center: 6000.4321
+      amplitude: 4.10e-21
+      gamma_air: 0.080
+      gamma_self: 0.095
+      e0: 156.2
+      n_air: 0.76
+      shift_air: -0.006
+      abundance: 0.997
+      gDicke: 0.018
+      nDicke: 0.27
+      lmf: 0.005
+      nlmf: 0.60

--- a/project/config/data_config.py
+++ b/project/config/data_config.py
@@ -1,0 +1,172 @@
+"""Utilities to load dataset-related YAML configuration files."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+from utils.io import load_config
+from config.params import PARAMS, NORM_PARAMS, LOG_SCALE_PARAMS
+
+
+_TRANSITION_REQUIRED_FIELDS: frozenset[str] = frozenset(
+    {
+        "mid",
+        "lid",
+        "center",
+        "amplitude",
+        "gamma_air",
+        "gamma_self",
+        "e0",
+        "n_air",
+        "shift_air",
+        "abundance",
+        "gDicke",
+        "nDicke",
+        "lmf",
+        "nlmf",
+    }
+)
+
+
+def _as_path(path: str | Path) -> Path:
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(f"Configuration file not found: {p}")
+    return p
+
+
+def load_parameter_ranges(path: str | Path, *, update_globals: bool = True) -> Dict[str, tuple[float, float]]:
+    """Load parameter ranges from a YAML configuration file.
+
+    The YAML file must contain a ``parameters`` mapping where each key is a
+    parameter name defined in :data:`config.params.PARAMS` and provides
+    ``min``/``max`` values. An optional ``log_scale`` flag updates
+    :data:`config.params.LOG_SCALE_PARAMS`.
+
+    Args:
+        path: Path to the YAML file.
+        update_globals: When ``True`` (default), ``config.params.NORM_PARAMS``
+            and ``config.params.LOG_SCALE_PARAMS`` are updated in-place.
+
+    Returns:
+        Dictionary mapping parameter names to ``(min, max)`` tuples.
+    """
+
+    cfg = load_config(str(_as_path(path)))
+    raw_params = cfg.get("parameters")
+    if not isinstance(raw_params, Mapping):
+        raise ValueError("YAML file must define a 'parameters' mapping")
+
+    missing: set[str] = set(PARAMS) - set(raw_params)
+    if missing:
+        raise ValueError(f"Missing parameter entries in YAML: {sorted(missing)}")
+
+    unknown = set(raw_params) - set(PARAMS)
+    if unknown:
+        raise ValueError(f"Unknown parameters in YAML: {sorted(unknown)}")
+
+    ranges: Dict[str, tuple[float, float]] = {}
+    new_log_scale: set[str] = set()
+
+    for name in PARAMS:
+        spec = raw_params[name]
+        if not isinstance(spec, Mapping):
+            raise ValueError(f"Parameter '{name}' configuration must be a mapping")
+        if "min" not in spec or "max" not in spec:
+            raise ValueError(f"Parameter '{name}' must define 'min' and 'max' values")
+        min_val = float(spec["min"])
+        max_val = float(spec["max"])
+        if min_val >= max_val:
+            raise ValueError(
+                f"Parameter '{name}' has invalid range: min ({min_val}) must be < max ({max_val})"
+            )
+        ranges[name] = (min_val, max_val)
+        if bool(spec.get("log_scale", False)):
+            new_log_scale.add(name)
+
+    if update_globals:
+        NORM_PARAMS.clear()
+        NORM_PARAMS.update(ranges)
+        # Update log-scale set without mutating the object reference
+        LOG_SCALE_PARAMS.clear()
+        LOG_SCALE_PARAMS.update(new_log_scale)
+
+    return ranges
+
+
+def load_noise_profile(path: str | Path) -> Dict[str, float | Iterable[float] | int]:
+    """Load noise augmentation parameters from YAML.
+
+    The YAML file must expose a ``noise`` mapping containing keyword arguments
+    compatible with :func:`data.noise.add_noise_variety`.
+    """
+
+    cfg = load_config(str(_as_path(path)))
+    noise = cfg.get("noise")
+    if not isinstance(noise, Mapping):
+        raise ValueError("YAML file must define a 'noise' mapping")
+    return dict(noise)
+
+
+def load_transitions(path: str | Path) -> Dict[str, list[dict]]:
+    """Load molecular transitions from YAML configuration.
+
+    Args:
+        path: Path to the YAML file describing molecular transitions.
+
+    Returns:
+        Dictionary mapping molecule identifiers (e.g. ``"CH4"``) to a list of
+        transition dictionaries compatible with
+        :func:`physics.transitions.transitions_to_tensors`.
+    """
+
+    cfg = load_config(str(_as_path(path)))
+    raw_transitions = cfg.get("transitions")
+    if not isinstance(raw_transitions, Mapping):
+        raise ValueError("YAML file must define a 'transitions' mapping")
+
+    transitions_dict: Dict[str, list[dict]] = {}
+    for mol, entries in raw_transitions.items():
+        if entries is None:
+            transitions_dict[mol] = []
+            continue
+        if not isinstance(entries, list):
+            raise ValueError(f"Transitions for molecule '{mol}' must be a list")
+        parsed_entries: list[dict] = []
+        for idx, entry in enumerate(entries):
+            if not isinstance(entry, Mapping):
+                raise ValueError(
+                    f"Transition #{idx} for molecule '{mol}' must be a mapping, got {type(entry).__name__}"
+                )
+            missing = _TRANSITION_REQUIRED_FIELDS - set(entry)
+            if missing:
+                raise ValueError(
+                    f"Transition #{idx} for molecule '{mol}' is missing fields: {sorted(missing)}"
+                )
+            parsed_entries.append(
+                {
+                    "mid": int(entry["mid"]),
+                    "lid": int(entry["lid"]),
+                    "center": float(entry["center"]),
+                    "amplitude": float(entry["amplitude"]),
+                    "gamma_air": float(entry["gamma_air"]),
+                    "gamma_self": float(entry["gamma_self"]),
+                    "e0": float(entry["e0"]),
+                    "n_air": float(entry["n_air"]),
+                    "shift_air": float(entry["shift_air"]),
+                    "abundance": float(entry["abundance"]),
+                    "gDicke": float(entry["gDicke"]),
+                    "nDicke": float(entry["nDicke"]),
+                    "lmf": float(entry["lmf"]),
+                    "nlmf": float(entry["nlmf"]),
+                }
+            )
+        transitions_dict[mol] = parsed_entries
+    return transitions_dict
+
+
+__all__ = [
+    "load_parameter_ranges",
+    "load_noise_profile",
+    "load_transitions",
+]


### PR DESCRIPTION
## Summary
- add default YAML configs for parameter ranges, noise, and transitions
- introduce helpers to load dataset-related YAML configs
- update the Stage A training script to consume the new YAML inputs via CLI flags

## Testing
- python -m compileall project/config/data_config.py project/examples/train_stage_a.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e024803f4832a92c13095ac6d15b9)