### PR TITLE
Align modular training pipeline with physae defaults

### DIFF
--- a/project/scripts/train.py
+++ b/project/scripts/train.py
@@ -1,172 +1,375 @@
-"""
-Main training script.
+"""Training entry-point mirroring the original ``physae.py`` workflow."""
+from __future__ import annotations
 
-This is a template for the training script. Adapt it to your specific needs based on
-the original training setup in physae.py.
-"""
 import argparse
-from pathlib import Path
-import pytorch_lightning as pl
-from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
-from torch.utils.data import DataLoader
-
-# Import project modules
 import sys
-sys.path.insert(0, str(Path(__file__).parent.parent))
+from pathlib import Path
+from typing import Dict, Iterable, Optional
 
-from config.params import NORM_PARAMS
-from data.dataset import SpectraDataset
-from models.autoencoder import PhysicallyInformedAE
-from physics.tips import Tips2021QTpy, find_qtpy_dir
-from training.callbacks.epoch_sync import UpdateEpochInDataset
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import (
+    LearningRateMonitor,
+    ModelCheckpoint,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from config.data_config import (  # noqa: E402
+    load_noise_profile,
+    load_parameter_ranges,
+    load_transitions,
+)
+from config.training_config import TrainingConfig  # noqa: E402
+from physics.tips import Tips2021QTpy, find_qtpy_dir  # noqa: E402
+from training.callbacks import (  # noqa: E402
+    LossCurvePlotCallback,
+    PT_PredVsExp_VisuCallback,
+    StageAwarePlotCallback,
+    UpdateEpochInDataset,
+    UpdateEpochInValDataset,
+)
+from training.factory import build_data_and_model  # noqa: E402
+from training.stages import (  # noqa: E402
+    train_refiner_idx,
+    train_stage_A,
+    train_stage_B1,
+    train_stage_B2,
+    train_stage_DENOISER,
+)
 
 
-def parse_args():
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description='Train PhysicallyInformedAE model')
-    parser.add_argument('--batch_size', type=int, default=32, help='Batch size')
-    parser.add_argument('--epochs', type=int, default=100, help='Number of epochs')
-    parser.add_argument('--lr', type=float, default=1e-4, help='Learning rate')
-    parser.add_argument('--gpus', type=int, default=1, help='Number of GPUs')
-    parser.add_argument('--num_workers', type=int, default=4, help='Number of data workers')
-    parser.add_argument('--static_train_set', action='store_true',
-                        help='Freeze parameter draws for the training dataset')
-    parser.add_argument('--static_val_set', action='store_true',
-                        help='Freeze parameter draws for the validation dataset')
-    parser.add_argument('--checkpoint_dir', type=str, default='./checkpoints', help='Checkpoint directory')
-    parser.add_argument('--qtpy_dir', type=str, default='./QTpy', help='QTpy directory')
+def _default_transitions_path() -> Path:
+    return REPO_ROOT / "config" / "data" / "transitions_sample.yaml"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train PhysicallyInformedAE with stage-aware defaults",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Stage configuration
+    parser.add_argument(
+        "--stage",
+        choices=["A", "B1", "B2", "DEN", "REFINER"],
+        default="A",
+        help="Training stage to execute",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        help="Override the default number of epochs for the selected stage",
+    )
+    parser.add_argument(
+        "--refiner-index",
+        type=int,
+        default=0,
+        help="Index of the refiner block to fine-tune when stage=REFINER",
+    )
+    parser.add_argument(
+        "--delta-scale",
+        type=float,
+        default=0.12,
+        help="Residual scaling factor for refiner fine-tuning",
+    )
+    parser.add_argument(
+        "--stage-a-exp-params",
+        nargs="*",
+        default=None,
+        help="Parameters kept at experimental ground truth during Stage A",
+    )
+    parser.add_argument(
+        "--refiner-exp-params",
+        nargs="*",
+        default=None,
+        help="Parameters treated as experimental during refiner stages",
+    )
+
+    # Dataset configuration
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--num-points", type=int, default=800, help="Spectral points")
+    parser.add_argument("--train-samples", type=int, default=500_000, help="Training samples")
+    parser.add_argument("--val-samples", type=int, default=5_000, help="Validation samples")
+    parser.add_argument("--batch-size", type=int, default=32, help="Batch size")
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=None,
+        help="DataLoader workers (None reproduces physae.py heuristic)",
+    )
+    parser.add_argument(
+        "--static-train-params",
+        action="store_true",
+        help="Freeze parameter draws for the training dataset",
+    )
+    parser.add_argument(
+        "--static-val-params",
+        action="store_true",
+        help="Freeze parameter draws for the validation dataset",
+    )
+    parser.add_argument(
+        "--freeze-val-noise",
+        action="store_true",
+        help="Keep validation noise realisations fixed across epochs",
+    )
+
+    # Configuration files
+    parser.add_argument(
+        "--train-parameters-config",
+        type=str,
+        help="YAML file overriding training parameter ranges",
+    )
+    parser.add_argument(
+        "--val-parameters-config",
+        type=str,
+        help="YAML file overriding validation parameter ranges",
+    )
+    parser.add_argument(
+        "--noise-train-config",
+        type=str,
+        help="YAML file overriding training noise profile",
+    )
+    parser.add_argument(
+        "--noise-val-config",
+        type=str,
+        help="YAML file overriding validation noise profile",
+    )
+    parser.add_argument(
+        "--transitions-config",
+        type=str,
+        help="YAML file describing spectroscopic transitions",
+    )
+    parser.add_argument(
+        "--qtpy-dir",
+        type=str,
+        default=None,
+        help="Directory containing QTpy partition function tables",
+    )
+
+    # Logging & checkpoints
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=str,
+        default="./checkpoints",
+        help="Directory used by ModelCheckpoint",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        default="./logs",
+        help="Root directory for diagnostic figures",
+    )
+    parser.add_argument("--ckpt-in", type=str, help="Checkpoint to load before training")
+    parser.add_argument(
+        "--ckpt-out",
+        type=str,
+        help="Checkpoint path saved after training (in addition to callbacks)",
+    )
+
+    # Trainer arguments
+    parser.add_argument("--accelerator", type=str, help="Lightning accelerator override")
+    parser.add_argument("--devices", type=int, help="Number of devices to use")
+    parser.add_argument("--precision", type=str, help="Numerical precision override")
+    parser.add_argument("--strategy", type=str, help="Training strategy (ddp, etc.)")
+    parser.add_argument(
+        "--limit-train-batches",
+        type=float,
+        help="Limit number of training batches (debug)",
+    )
+    parser.add_argument(
+        "--limit-val-batches",
+        type=float,
+        help="Limit number of validation batches (debug)",
+    )
+    parser.add_argument(
+        "--enable-progress-bar",
+        action="store_true",
+        help="Display Lightning progress bar",
+    )
+    parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="Force deterministic training",
+    )
+
     return parser.parse_args()
 
 
-def create_datasets(args):
-    """
-    Create train and validation datasets.
-
-    Args:
-        args: Command line arguments.
-
-    Returns:
-        Tuple of (train_dataset, val_dataset).
-    """
-    # Initialize TIPS partition functions
-    qtpy_dir = find_qtpy_dir(args.qtpy_dir)
-    tipspy = Tips2021QTpy(qtpy_dir, device='cpu')
-
-    # TODO: Load transitions data
-    # This should be loaded from your specific data files
-    transitions_dict = {
-        # 'CH4': transitions_CH4,
-        # 'H2O': transitions_H2O,
-    }
-
-    # TODO: Define polynomial frequency coefficients. Provide the exact values
-    # from your spectrometer calibration; pass ``None`` to rely on a linear grid
-    # when no correction is available.
-    poly_freq_CH4 = None
-
-    # Create datasets
-    train_dataset = SpectraDataset(
-        n_samples=10000,
-        num_points=1024,  # Adjust to your data
-        poly_freq_CH4=poly_freq_CH4,
-        transitions_dict=transitions_dict,
-        sample_ranges=NORM_PARAMS,
-        with_noise=True,
-        tipspy=tipspy,
-    )
-
-    train_dataset.freeze_parameter_draws(args.static_train_set)
-
-    val_dataset = SpectraDataset(
-        n_samples=1000,
-        num_points=1024,
-        poly_freq_CH4=poly_freq_CH4,
-        transitions_dict=transitions_dict,
-        sample_ranges=NORM_PARAMS,
-        with_noise=True,
-        freeze_noise=True,  # Fixed noise for validation
-        tipspy=tipspy,
-    )
-
-    val_dataset.freeze_parameter_draws(args.static_val_set)
-
-    return train_dataset, val_dataset
+def _load_parameter_ranges(path: Optional[str]) -> Optional[Dict[str, tuple[float, float]]]:
+    if path is None:
+        return None
+    return load_parameter_ranges(path, update_globals=False)
 
 
-def main():
-    """Main training function."""
-    args = parse_args()
+def _load_noise(path: Optional[str]) -> Optional[Dict[str, object]]:
+    if path is None:
+        return None
+    return load_noise_profile(path)
 
-    # Set seed for reproducibility
-    pl.seed_everything(42)
 
-    # Create datasets
-    print("Creating datasets...")
-    train_dataset, val_dataset = create_datasets(args)
+def _load_transitions(path: Optional[str]) -> tuple[Dict[str, Iterable], Dict[str, Iterable]]:
+    cfg_path = Path(path) if path else _default_transitions_path()
+    return load_transitions(cfg_path, include_poly_freq=True)
 
-    # Create dataloaders
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=args.batch_size,
-        shuffle=True,
-        num_workers=args.num_workers,
-        pin_memory=True,
-    )
 
-    val_loader = DataLoader(
-        val_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        num_workers=args.num_workers,
-        pin_memory=True,
-    )
+def _create_callbacks(
+    stage: str,
+    model,
+    val_loader,
+    log_dir: Path,
+    checkpoint_dir: Path,
+) -> list:
+    stage_tag = f"Stage{stage.upper()}"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "loss_curves").mkdir(parents=True, exist_ok=True)
+    stage_fig_dir = log_dir / "figures" / stage_tag.lower()
+    stage_fig_dir.mkdir(parents=True, exist_ok=True)
+    (checkpoint_dir / stage_tag.lower()).mkdir(parents=True, exist_ok=True)
 
-    # TODO: Load transitions data
-    transitions_dict = {}
-    poly_freq_CH4 = None
-
-    # Create model
-    print("Creating model...")
-    model = PhysicallyInformedAE(
-        n_points=1024,
-        param_names=['sig0', 'dsig', 'mf_CH4', 'baseline0', 'baseline1', 'baseline2', 'P', 'T'],
-        poly_freq_CH4=poly_freq_CH4,
-        transitions_dict=transitions_dict,
-        lr=args.lr,
-    )
-
-    # Setup callbacks
     callbacks = [
-        ModelCheckpoint(
-            dirpath=args.checkpoint_dir,
-            filename='physae-{epoch:02d}-{val_loss:.4f}',
-            monitor='val_loss',
-            mode='min',
-            save_top_k=3,
+        StageAwarePlotCallback(
+            val_loader=val_loader,
+            param_names=model.param_names,
+            num_examples=1,
+            save_dir=stage_fig_dir,
+            stage_tag=stage_tag,
+            refine=stage.upper() not in {"A", "DEN"},
+            use_gt_for_provided=True,
+            recon_PT="pred",
+            max_val_batches=10,
         ),
-        EarlyStopping(
-            monitor='val_loss',
-            patience=20,
-            mode='min',
+        PT_PredVsExp_VisuCallback(
+            val_loader=val_loader,
+            save_dir=stage_fig_dir / "pt_compare",
+            num_examples=1,
+            tag=f"{stage_tag}_PT",
+            use_gt_for_provided=True,
+        ),
+        LossCurvePlotCallback(
+            save_path=log_dir / "loss_curves" / f"{stage_tag.lower()}_curves.png"
         ),
         UpdateEpochInDataset(),
+        UpdateEpochInValDataset(),
+        ModelCheckpoint(
+            dirpath=checkpoint_dir / stage_tag.lower(),
+            filename=f"physae-{stage_tag.lower()}-{{epoch:03d}}-{{val_loss:.4f}}",
+            monitor="val_loss",
+            mode="min",
+            save_top_k=3,
+            save_last=True,
+        ),
+        LearningRateMonitor(logging_interval="epoch"),
     ]
+    return callbacks
 
-    # Create trainer
-    trainer = pl.Trainer(
-        max_epochs=args.epochs,
-        accelerator='gpu' if args.gpus > 0 else 'cpu',
-        devices=args.gpus if args.gpus > 0 else None,
-        callbacks=callbacks,
-        log_every_n_steps=50,
+
+def _trainer_kwargs_from_args(args: argparse.Namespace) -> dict:
+    trainer_kwargs: Dict[str, object] = {}
+    for key in ("accelerator", "devices", "precision", "strategy"):
+        value = getattr(args, key)
+        if value is not None:
+            trainer_kwargs[key] = value
+    for key in ("limit_train_batches", "limit_val_batches"):
+        value = getattr(args, key)
+        if value is not None:
+            trainer_kwargs[key] = value
+    if args.deterministic:
+        trainer_kwargs["deterministic"] = True
+    return trainer_kwargs
+
+
+def main() -> None:
+    args = parse_args()
+
+    pl.seed_everything(args.seed)
+
+    config = TrainingConfig(
+        seed=args.seed,
+        n_points=args.num_points,
+        n_train=args.train_samples,
+        n_val=args.val_samples,
+        batch_size=args.batch_size,
     )
 
-    # Train
-    print("Starting training...")
-    trainer.fit(model, train_loader, val_loader)
+    train_ranges = _load_parameter_ranges(args.train_parameters_config)
+    if train_ranges is not None:
+        config.train_ranges = train_ranges
+    val_ranges = _load_parameter_ranges(args.val_parameters_config)
+    if val_ranges is not None:
+        config.val_ranges = val_ranges
 
-    print("Training complete!")
+    noise_train = _load_noise(args.noise_train_config)
+    if noise_train is not None:
+        config.noise_train = noise_train
+    noise_val = _load_noise(args.noise_val_config)
+    if noise_val is not None:
+        config.noise_val = noise_val
+
+    transitions_dict, poly_freq_map = _load_transitions(args.transitions_config)
+    poly_freq_CH4 = poly_freq_map.get("CH4")
+
+    tipspy = None
+    try:
+        qtpy_dir = find_qtpy_dir(args.qtpy_dir or "./QTpy")
+        tipspy = Tips2021QTpy(qtpy_dir, device="cpu")
+        print(f"✓ TIPS2021 chargé depuis: {qtpy_dir}")
+    except Exception as exc:  # pragma: no cover - best effort informative message
+        print(f"⚠️ Impossible de charger TIPS2021 ({exc}). La simulation physique utilisera None.")
+
+    model, train_loader, val_loader = build_data_and_model(
+        config,
+        transitions_dict=transitions_dict,
+        poly_freq_CH4=poly_freq_CH4,
+        tipspy=tipspy,
+        freeze_train_parameters=args.static_train_params,
+        freeze_val_parameters=args.static_val_params,
+        freeze_val_noise=args.freeze_val_noise,
+        num_workers=args.num_workers,
+        stage=args.stage,
+    )
+
+    log_dir = Path(args.log_dir)
+    checkpoint_dir = Path(args.checkpoint_dir)
+    callbacks = _create_callbacks(args.stage, model, val_loader, log_dir, checkpoint_dir)
+
+    stage_kwargs = dict(
+        callbacks=callbacks,
+        enable_progress_bar=args.enable_progress_bar,
+        ckpt_in=args.ckpt_in,
+        ckpt_out=args.ckpt_out,
+        **_trainer_kwargs_from_args(args),
+    )
+    if args.epochs is not None:
+        stage_kwargs["epochs"] = args.epochs
+
+    stage = args.stage.upper()
+    if stage == "A":
+        if args.stage_a_exp_params:
+            stage_kwargs["use_exp_params"] = args.stage_a_exp_params
+        train_stage_A(model, train_loader, val_loader, **stage_kwargs)
+    elif stage == "B1":
+        train_stage_B1(model, train_loader, val_loader, **stage_kwargs)
+    elif stage == "B2":
+        train_stage_B2(model, train_loader, val_loader, **stage_kwargs)
+    elif stage == "DEN":
+        train_stage_DENOISER(model, train_loader, val_loader, **stage_kwargs)
+    else:
+        if args.refiner_exp_params:
+            stage_kwargs["use_exp_params_for_resid"] = args.refiner_exp_params
+        stage_kwargs.setdefault("refiner_lr", 1e-4)
+        stage_kwargs.setdefault("delta_scale", args.delta_scale)
+        train_refiner_idx(
+            model,
+            train_loader,
+            val_loader,
+            k=int(args.refiner_index),
+            **stage_kwargs,
+        )
+
+    print("✅ Entraînement terminé")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/project/training/factory.py
+++ b/project/training/factory.py
@@ -1,0 +1,177 @@
+"""Utilities to mirror ``physae.py``'s data/model preparation pipeline."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+import torch
+from torch.utils.data import DataLoader
+
+from config import params as params_cfg
+from config.training_config import TrainingConfig
+from data.dataset import SpectraDataset
+from models.autoencoder import PhysicallyInformedAE
+
+
+def _default_num_workers() -> int:
+    """Replicate the platform-dependent worker heuristic from ``physae.py``."""
+    import sys
+
+    return 0 if sys.platform == "win32" else 4
+
+
+def prepare_datasets(
+    config: TrainingConfig,
+    *,
+    poly_freq_CH4,
+    transitions_dict: Dict[str, Iterable],
+    tipspy=None,
+    freeze_train_parameters: bool = False,
+    freeze_val_parameters: bool = False,
+    freeze_val_noise: bool = False,
+    num_workers: int | None = None,
+    pin_memory: bool | None = None,
+) -> Tuple[DataLoader, DataLoader]:
+    """Create train/validation dataloaders matching ``physae.py`` defaults."""
+
+    dataset_cfg = config.dataset_kwargs()
+
+    # Align global normalisation with the training ranges as the monolithic
+    # script did inside ``build_data_and_model``.
+    params_cfg.NORM_PARAMS.clear()
+    params_cfg.NORM_PARAMS.update(dataset_cfg["train_ranges"])
+
+    if num_workers is None:
+        num_workers = _default_num_workers()
+
+    if pin_memory is None:
+        pin_memory = torch.cuda.is_available()
+
+    train_dataset = SpectraDataset(
+        n_samples=dataset_cfg["n_train"],
+        num_points=dataset_cfg["n_points"],
+        poly_freq_CH4=poly_freq_CH4,
+        transitions_dict=transitions_dict,
+        sample_ranges=dataset_cfg["train_ranges"],
+        strict_check=True,
+        with_noise=True,
+        noise_profile=dataset_cfg["noise_train"],
+        freeze_parameters=freeze_train_parameters,
+        freeze_noise=False,
+        tipspy=tipspy,
+    )
+
+    val_dataset = SpectraDataset(
+        n_samples=dataset_cfg["n_val"],
+        num_points=dataset_cfg["n_points"],
+        poly_freq_CH4=poly_freq_CH4,
+        transitions_dict=transitions_dict,
+        sample_ranges=dataset_cfg["val_ranges"],
+        strict_check=True,
+        with_noise=True,
+        noise_profile=dataset_cfg["noise_val"],
+        freeze_parameters=freeze_val_parameters,
+        freeze_noise=freeze_val_noise,
+        tipspy=tipspy,
+    )
+
+    persistent = num_workers > 0
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=dataset_cfg["batch_size"],
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+        persistent_workers=persistent,
+    )
+
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=dataset_cfg["batch_size"],
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+        persistent_workers=persistent,
+    )
+
+    return train_loader, val_loader
+
+
+def prepare_model(
+    config: TrainingConfig,
+    *,
+    transitions_dict: Dict[str, Iterable],
+    poly_freq_CH4,
+    tipspy=None,
+    stage: str | None = None,
+) -> PhysicallyInformedAE:
+    """Instantiate :class:`PhysicallyInformedAE` with faithful defaults."""
+
+    model_kwargs = config.model_kwargs()
+    if stage is not None:
+        model_kwargs.update(config.stage_overrides(stage))
+
+    model = PhysicallyInformedAE(
+        poly_freq_CH4=poly_freq_CH4,
+        transitions_dict=transitions_dict,
+        tipspy=tipspy,
+        **model_kwargs,
+    )
+
+    # Match optimisation defaults from the monolithic script.
+    model.hparams.optimizer = "lion"
+    model.hparams.betas = (0.9, 0.99)
+    model.weight_decay = 1e-4
+
+    print("\n" + "=" * 70)
+    print("🔍 Vérification des poids de loss")
+    print("=" * 70)
+    print(f"w_pw_raw          = {model.w_pw_raw}")
+    print(f"w_spectral_angle  = {model.w_spectral_angle}")
+    print(f"w_peak            = {model.w_peak}")
+    print(f"w_params          = {model.w_params}")
+    print(f"use_relobralo_top = {model.use_relobralo_top}")
+    print(f"peak_loss         = {type(model.peak_weighted_loss).__name__}")
+    if model.use_relobralo_top and getattr(model, "relo_top", None) is not None:
+        print(f"relo_top          = {type(model.relo_top).__name__} (actif)")
+    print("=" * 70 + "\n")
+
+    return model
+
+
+def build_data_and_model(
+    config: TrainingConfig,
+    *,
+    transitions_dict: Dict[str, Iterable],
+    poly_freq_CH4,
+    tipspy=None,
+    freeze_train_parameters: bool = False,
+    freeze_val_parameters: bool = False,
+    freeze_val_noise: bool = False,
+    num_workers: int | None = None,
+    pin_memory: bool | None = None,
+    stage: str | None = None,
+) -> Tuple[PhysicallyInformedAE, DataLoader, DataLoader]:
+    """Convenience wrapper mirroring ``physae.py``'s helper."""
+
+    train_loader, val_loader = prepare_datasets(
+        config,
+        poly_freq_CH4=poly_freq_CH4,
+        transitions_dict=transitions_dict,
+        tipspy=tipspy,
+        freeze_train_parameters=freeze_train_parameters,
+        freeze_val_parameters=freeze_val_parameters,
+        freeze_val_noise=freeze_val_noise,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+    )
+
+    model = prepare_model(
+        config,
+        transitions_dict=transitions_dict,
+        poly_freq_CH4=poly_freq_CH4,
+        tipspy=tipspy,
+        stage=stage,
+    )
+
+    return model, train_loader, val_loader


### PR DESCRIPTION
## Summary
- add a training.factory helper that reproduces physae.py's build_data_and_model behaviour for datasets, dataloaders, and model defaults
- replace project/scripts/train.py with a stage-aware CLI that consumes the factory, callbacks, and stage utilities so the modular workflow matches the original physae training pipeline

## Testing
- python -m compileall project/training/factory.py project/scripts/train.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6bc68df4832a899a2d000ee9f539)