### PR TITLE
Support complex-only noise profiles

### DIFF
--- a/physae.py
+++ b/physae.py
@@ -564,6 +564,12 @@ def batch_physics_forward_multimol_vgrid(
 # 3) Dataset & bruits
 # ============================================================
 def add_noise_variety(spectra, *, generator=None, **cfg):
+    cfg = dict(cfg)
+    legacy_enabled = bool(cfg.pop("legacy_enabled", True))
+
+    if not legacy_enabled:
+        return spectra.clone()
+
     std_add_range     = cfg.get("std_add_range", (0.001, 0.01))
     std_mult_range    = cfg.get("std_mult_range", (0.002, 0.02))
     p_drift           = cfg.get("p_drift", 0.7)

--- a/project/config/data/noise_default.yaml
+++ b/project/config/data/noise_default.yaml
@@ -1,5 +1,6 @@
 # Profil de bruit repris de build_data_and_model dans physae.py.
 noise:
+  legacy_enabled: false
   std_add_range: [0.0, 0.005]
   std_mult_range: [0.0, 0.005]
   p_drift: 0.2
@@ -15,11 +16,10 @@ noise:
   spike_width_range: [1.0, 200.0]
   clip: [0.0, 1.5]
   complex:
-    probability: 0.75
+    probability: 1.0
     noise_types: [gaussian, shot, flicker, etaloning, glitches]
     noise_type_weights: [0.25, 0.15, 0.2, 0.15, 0.25]
     noise_level_range: [0.4, 1.6]
     max_rel_to_line: 0.10
-    mode: blend
-    blend_alpha: 0.35
+    mode: replace
     clip: [0.0, 1.5]

--- a/project/examples/notebooks/noise_profiles_visualisation.ipynb
+++ b/project/examples/notebooks/noise_profiles_visualisation.ipynb
@@ -1,0 +1,239 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Visualisation des bruits complexes\n",
+        "\n",
+        "Ce notebook permet d'explorer l'influence du paramètre `noise_level` (de 0.0 à 2.0, par pas de 0.1) sur chacun des profils de bruit complexe disponibles dans `project.data.noise`. Pour chaque combinaison type/niveau, cinq réalisations indépendantes sont générées afin d'illustrer la variabilité statistique du procédé de synthèse."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Préparation\n",
+        "\n",
+        "On commence par importer les dépendances nécessaires et par définir un spectre synthétique propre qui servira de référence pour l'étude. Ce spectre propre reproduit grossièrement plusieurs raies d'absorption sur un continuum unitaire."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import torch\n",
+        "import matplotlib.pyplot as plt\n",
+        "from IPython.display import display\n",
+        "import ipywidgets as widgets\n",
+        "\n",
+        "from project.data.noise import add_noise_variety\n",
+        "\n",
+        "plt.rcParams['figure.figsize'] = (10, 4)\n",
+        "plt.rcParams['axes.grid'] = True\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "torch.manual_seed(0)\n",
+        "np.random.seed(0)\n",
+        "\n",
+        "spectral_length = 1024\n",
+        "x = torch.linspace(0.0, 1.0, spectral_length)\n",
+        "\n",
+        "# Construction d'un spectre propre synthétique avec plusieurs raies d'absorption.\n",
+        "def build_clean_spectrum(x: torch.Tensor) -> torch.Tensor:\n",
+        "    centers = torch.tensor([0.18, 0.32, 0.58, 0.76])\n",
+        "    widths = torch.tensor([0.015, 0.030, 0.020, 0.025])\n",
+        "    depths = torch.tensor([0.35, 0.25, 0.40, 0.30])\n",
+        "\n",
+        "    spectrum = torch.ones_like(x)\n",
+        "    for c, w, d in zip(centers, widths, depths):\n",
+        "        spectrum = spectrum - d * torch.exp(-0.5 * ((x - c) / w) ** 2)\n",
+        "    # Légère modulation pour imiter une pente instrumentale.\n",
+        "    spectrum = spectrum * (1.0 + 0.05 * torch.sin(2 * torch.pi * x))\n",
+        "    return spectrum\n",
+        "\n",
+        "clean_reference = build_clean_spectrum(x)\n",
+        "# Baseline normalisée supposée à 1 pour tous les pixels.\n",
+        "baseline_reference = torch.ones_like(clean_reference)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Visualisons le spectre propre qui servira de base à toutes les simulations de bruit."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "fig, ax = plt.subplots()\n",
+        "ax.plot(x.numpy(), clean_reference.numpy(), color='black', linewidth=2, label='Spectre propre')\n",
+        "ax.set_xlabel('Position spectrale normalisée')\n",
+        "ax.set_ylabel('Intensité normalisée')\n",
+        "ax.set_title('Spectre synthétique de référence')\n",
+        "ax.legend()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Génération des échantillons bruités\n",
+        "\n",
+        "Nous balayons les valeurs de `noise_level` de 0.0 à 2.0 par pas de 0.1. Pour chaque tranche, cinq exemples indépendants sont créés via `add_noise_variety` en désactivant le pipeline de bruit *legacy* pour ne conserver que le profil complexe demandé."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "noise_types = ['gaussian', 'shot', 'flicker', 'etaloning', 'glitches']\n",
+        "noise_levels = np.round(np.arange(0.0, 2.0 + 1e-6, 0.1), 1)\n",
+        "examples_per_level = 5\n",
+        "\n",
+        "# Dictionnaire: type -> niveau -> échantillons (examples_per_level, spectral_length)\n",
+        "noise_samples = {noise_type: {} for noise_type in noise_types}\n",
+        "\n",
+        "for t_idx, noise_type in enumerate(noise_types):\n",
+        "    for l_idx, level in enumerate(noise_levels):\n",
+        "        level_key = f\"{level:.1f}\"\n",
+        "        generator = torch.Generator().manual_seed(10_000 * t_idx + l_idx)\n",
+        "        batch_clean = clean_reference.unsqueeze(0).repeat(examples_per_level, 1)\n",
+        "        batch_baseline = baseline_reference.unsqueeze(0).repeat(examples_per_level, 1)\n",
+        "        noisy = add_noise_variety(\n",
+        "            batch_clean,\n",
+        "            baseline_norm=batch_baseline,\n",
+        "            generator=generator,\n",
+        "            legacy_enabled=False,\n",
+        "            complex={\n",
+        "                'mode': 'replace',\n",
+        "                'noise_type': noise_type,\n",
+        "                'noise_level': float(level),\n",
+        "                'max_rel_to_line': 0.15,\n",
+        "                'clip': (0.0, 1.4),\n",
+        "            },\n",
+        "        )\n",
+        "        noise_samples[noise_type][level_key] = noisy.detach().cpu().numpy()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Visualisation interactive\n",
+        "\n",
+        "Utilisez les contrôles ci-dessous pour sélectionner un type de bruit et une tranche de `noise_level`. Le spectre propre est tracé en noir et les cinq réalisations correspondant à la tranche choisie sont affichées en couleur."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "palette = plt.cm.viridis(np.linspace(0, 1, examples_per_level))\n",
+        "\n",
+        "noise_selector = widgets.Dropdown(\n",
+        "    options=[(nt.capitalize(), nt) for nt in noise_types],\n",
+        "    value='gaussian',\n",
+        "    description='Type:',\n",
+        ")\n",
+        "\n",
+        "level_selector = widgets.SelectionSlider(\n",
+        "    options=[(f\"{lvl:.1f}\", f\"{lvl:.1f}\") for lvl in noise_levels],\n",
+        "    value=f\"{noise_levels[0]:.1f}\",\n",
+        "    description='Niveau:',\n",
+        "    continuous_update=False,\n",
+        ")\n",
+        "\n",
+        "output = widgets.Output()\n",
+        "\n",
+        "\n",
+        "def plot_examples(noise_type: str, level_key: str) -> None:\n",
+        "    output.clear_output(wait=True)\n",
+        "    examples = noise_samples[noise_type][level_key]\n",
+        "\n",
+        "    with output:\n",
+        "        fig, ax = plt.subplots(figsize=(10, 4))\n",
+        "        ax.plot(x.numpy(), clean_reference.numpy(), color='black', linewidth=2, label='Propre')\n",
+        "        for idx in range(examples_per_level):\n",
+        "            ax.plot(x.numpy(), examples[idx], color=palette[idx], alpha=0.8, label=f'Exemple {idx + 1}')\n",
+        "        ax.set_xlabel('Position spectrale normalisée')\n",
+        "        ax.set_ylabel('Intensité normalisée')\n",
+        "        ax.set_title(f\"{noise_type.capitalize()} — noise_level = {level_key}\")\n",
+        "        ax.set_ylim(0.0, 1.4)\n",
+        "        ax.legend(loc='upper right', ncol=2)\n",
+        "        plt.show()\n",
+        "\n",
+        "\n",
+        "def on_change(change):\n",
+        "    plot_examples(noise_selector.value, level_selector.value)\n",
+        "\n",
+        "noise_selector.observe(on_change, names='value')\n",
+        "level_selector.observe(on_change, names='value')\n",
+        "\n",
+        "controls = widgets.HBox([noise_selector, level_selector])\n",
+        "display(controls, output)\n",
+        "\n",
+        "plot_examples(noise_selector.value, level_selector.value)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Statistiques rapides\n",
+        "\n",
+        "Le tableau suivant résume l'écart-type moyen du bruit ajouté pour chaque combinaison type/niveau, calculé en soustrayant le spectre propre. Il permet de visualiser globalement la croissance de l'amplitude du bruit lorsque `noise_level` augmente."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "\n",
+        "rows = []\n",
+        "for noise_type in noise_types:\n",
+        "    for level_key, noisy in noise_samples[noise_type].items():\n",
+        "        residual = noisy - clean_reference.numpy()\n",
+        "        rms = np.sqrt(np.mean(residual**2, axis=1))\n",
+        "        rows.append({'Type': noise_type, 'noise_level': float(level_key), 'RMS moyen': float(rms.mean())})\n",
+        "\n",
+        "summary_df = pd.DataFrame(rows).pivot(index='noise_level', columns='Type', values='RMS moyen')\n",
+        "display(summary_df)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/project/examples/notebooks/noise_profiles_visualisation.ipynb
+++ b/project/examples/notebooks/noise_profiles_visualisation.ipynb
@@ -1,239 +1,298 @@
-{
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Visualisation des bruits complexes\n",
-        "\n",
-        "Ce notebook permet d'explorer l'influence du paramètre `noise_level` (de 0.0 à 2.0, par pas de 0.1) sur chacun des profils de bruit complexe disponibles dans `project.data.noise`. Pour chaque combinaison type/niveau, cinq réalisations indépendantes sont générées afin d'illustrer la variabilité statistique du procédé de synthèse."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Préparation\n",
-        "\n",
-        "On commence par importer les dépendances nécessaires et par définir un spectre synthétique propre qui servira de référence pour l'étude. Ce spectre propre reproduit grossièrement plusieurs raies d'absorption sur un continuum unitaire."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "import torch\n",
-        "import matplotlib.pyplot as plt\n",
-        "from IPython.display import display\n",
-        "import ipywidgets as widgets\n",
-        "\n",
-        "from project.data.noise import add_noise_variety\n",
-        "\n",
-        "plt.rcParams['figure.figsize'] = (10, 4)\n",
-        "plt.rcParams['axes.grid'] = True\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "torch.manual_seed(0)\n",
-        "np.random.seed(0)\n",
-        "\n",
-        "spectral_length = 1024\n",
-        "x = torch.linspace(0.0, 1.0, spectral_length)\n",
-        "\n",
-        "# Construction d'un spectre propre synthétique avec plusieurs raies d'absorption.\n",
-        "def build_clean_spectrum(x: torch.Tensor) -> torch.Tensor:\n",
-        "    centers = torch.tensor([0.18, 0.32, 0.58, 0.76])\n",
-        "    widths = torch.tensor([0.015, 0.030, 0.020, 0.025])\n",
-        "    depths = torch.tensor([0.35, 0.25, 0.40, 0.30])\n",
-        "\n",
-        "    spectrum = torch.ones_like(x)\n",
-        "    for c, w, d in zip(centers, widths, depths):\n",
-        "        spectrum = spectrum - d * torch.exp(-0.5 * ((x - c) / w) ** 2)\n",
-        "    # Légère modulation pour imiter une pente instrumentale.\n",
-        "    spectrum = spectrum * (1.0 + 0.05 * torch.sin(2 * torch.pi * x))\n",
-        "    return spectrum\n",
-        "\n",
-        "clean_reference = build_clean_spectrum(x)\n",
-        "# Baseline normalisée supposée à 1 pour tous les pixels.\n",
-        "baseline_reference = torch.ones_like(clean_reference)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Visualisons le spectre propre qui servira de base à toutes les simulations de bruit."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "fig, ax = plt.subplots()\n",
-        "ax.plot(x.numpy(), clean_reference.numpy(), color='black', linewidth=2, label='Spectre propre')\n",
-        "ax.set_xlabel('Position spectrale normalisée')\n",
-        "ax.set_ylabel('Intensité normalisée')\n",
-        "ax.set_title('Spectre synthétique de référence')\n",
-        "ax.legend()\n",
-        "plt.show()\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Génération des échantillons bruités\n",
-        "\n",
-        "Nous balayons les valeurs de `noise_level` de 0.0 à 2.0 par pas de 0.1. Pour chaque tranche, cinq exemples indépendants sont créés via `add_noise_variety` en désactivant le pipeline de bruit *legacy* pour ne conserver que le profil complexe demandé."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "noise_types = ['gaussian', 'shot', 'flicker', 'etaloning', 'glitches']\n",
-        "noise_levels = np.round(np.arange(0.0, 2.0 + 1e-6, 0.1), 1)\n",
-        "examples_per_level = 5\n",
-        "\n",
-        "# Dictionnaire: type -> niveau -> échantillons (examples_per_level, spectral_length)\n",
-        "noise_samples = {noise_type: {} for noise_type in noise_types}\n",
-        "\n",
-        "for t_idx, noise_type in enumerate(noise_types):\n",
-        "    for l_idx, level in enumerate(noise_levels):\n",
-        "        level_key = f\"{level:.1f}\"\n",
-        "        generator = torch.Generator().manual_seed(10_000 * t_idx + l_idx)\n",
-        "        batch_clean = clean_reference.unsqueeze(0).repeat(examples_per_level, 1)\n",
-        "        batch_baseline = baseline_reference.unsqueeze(0).repeat(examples_per_level, 1)\n",
-        "        noisy = add_noise_variety(\n",
-        "            batch_clean,\n",
-        "            baseline_norm=batch_baseline,\n",
-        "            generator=generator,\n",
-        "            legacy_enabled=False,\n",
-        "            complex={\n",
-        "                'mode': 'replace',\n",
-        "                'noise_type': noise_type,\n",
-        "                'noise_level': float(level),\n",
-        "                'max_rel_to_line': 0.15,\n",
-        "                'clip': (0.0, 1.4),\n",
-        "            },\n",
-        "        )\n",
-        "        noise_samples[noise_type][level_key] = noisy.detach().cpu().numpy()\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Visualisation interactive\n",
-        "\n",
-        "Utilisez les contrôles ci-dessous pour sélectionner un type de bruit et une tranche de `noise_level`. Le spectre propre est tracé en noir et les cinq réalisations correspondant à la tranche choisie sont affichées en couleur."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "palette = plt.cm.viridis(np.linspace(0, 1, examples_per_level))\n",
-        "\n",
-        "noise_selector = widgets.Dropdown(\n",
-        "    options=[(nt.capitalize(), nt) for nt in noise_types],\n",
-        "    value='gaussian',\n",
-        "    description='Type:',\n",
-        ")\n",
-        "\n",
-        "level_selector = widgets.SelectionSlider(\n",
-        "    options=[(f\"{lvl:.1f}\", f\"{lvl:.1f}\") for lvl in noise_levels],\n",
-        "    value=f\"{noise_levels[0]:.1f}\",\n",
-        "    description='Niveau:',\n",
-        "    continuous_update=False,\n",
-        ")\n",
-        "\n",
-        "output = widgets.Output()\n",
-        "\n",
-        "\n",
-        "def plot_examples(noise_type: str, level_key: str) -> None:\n",
-        "    output.clear_output(wait=True)\n",
-        "    examples = noise_samples[noise_type][level_key]\n",
-        "\n",
-        "    with output:\n",
-        "        fig, ax = plt.subplots(figsize=(10, 4))\n",
-        "        ax.plot(x.numpy(), clean_reference.numpy(), color='black', linewidth=2, label='Propre')\n",
-        "        for idx in range(examples_per_level):\n",
-        "            ax.plot(x.numpy(), examples[idx], color=palette[idx], alpha=0.8, label=f'Exemple {idx + 1}')\n",
-        "        ax.set_xlabel('Position spectrale normalisée')\n",
-        "        ax.set_ylabel('Intensité normalisée')\n",
-        "        ax.set_title(f\"{noise_type.capitalize()} — noise_level = {level_key}\")\n",
-        "        ax.set_ylim(0.0, 1.4)\n",
-        "        ax.legend(loc='upper right', ncol=2)\n",
-        "        plt.show()\n",
-        "\n",
-        "\n",
-        "def on_change(change):\n",
-        "    plot_examples(noise_selector.value, level_selector.value)\n",
-        "\n",
-        "noise_selector.observe(on_change, names='value')\n",
-        "level_selector.observe(on_change, names='value')\n",
-        "\n",
-        "controls = widgets.HBox([noise_selector, level_selector])\n",
-        "display(controls, output)\n",
-        "\n",
-        "plot_examples(noise_selector.value, level_selector.value)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Statistiques rapides\n",
-        "\n",
-        "Le tableau suivant résume l'écart-type moyen du bruit ajouté pour chaque combinaison type/niveau, calculé en soustrayant le spectre propre. Il permet de visualiser globalement la croissance de l'amplitude du bruit lorsque `noise_level` augmente."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "rows = []\n",
-        "for noise_type in noise_types:\n",
-        "    for level_key, noisy in noise_samples[noise_type].items():\n",
-        "        residual = noisy - clean_reference.numpy()\n",
-        "        rms = np.sqrt(np.mean(residual**2, axis=1))\n",
-        "        rows.append({'Type': noise_type, 'noise_level': float(level_key), 'RMS moyen': float(rms.mean())})\n",
-        "\n",
-        "summary_df = pd.DataFrame(rows).pivot(index='noise_level', columns='Type', values='RMS moyen')\n",
-        "display(summary_df)\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.10"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 5
-}
+diff --git a/project/examples/notebooks/noise_profiles_visualisation.ipynb b/project/examples/notebooks/noise_profiles_visualisation.ipynb
+new file mode 100644
+index 0000000000000000000000000000000000000000..87fb1fcd45c1897451f5ca25ee19cf76dd79ef8f
+--- /dev/null
++++ b/project/examples/notebooks/noise_profiles_visualisation.ipynb
+@@ -0,0 +1,291 @@
++{
++ "cells": [
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "# Visualisation des bruits complexes\n",
++    "\n",
++    "Ce notebook permet d'explorer l'influence du paramètre `noise_level` (de 0.0 à 2.0, par pas de 0.1) sur chacun des profils de bruit complexe disponibles dans `project.data.noise`. Pour chaque combinaison type/niveau, cinq réalisations indépendantes sont générées afin d'illustrer la variabilité statistique du procédé de synthèse."
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Préparation\n",
++    "\n",
++    "On commence par importer les dépendances nécessaires et par définir un spectre synthétique propre qui servira de référence pour l'étude. Ce spectre propre reproduit grossièrement plusieurs raies d'absorption sur un continuum unitaire."
++   ]
++  },
++  {
++   "cell_type": "code",
++   "metadata": {},
++   "execution_count": null,
++   "outputs": [],
++   "source": [
++    "import sys\n",
++    "from pathlib import Path\n",
++    "\n",
++    "import numpy as np\n",
++    "import torch\n",
++    "import matplotlib.pyplot as plt\n",
++    "\n",
++    "from IPython.display import display\n",
++    "import ipywidgets as widgets\n",
++    "\n",
++    "PROJECT_ROOT = Path.cwd()\n",
++    "if not (PROJECT_ROOT / 'project').is_dir():\n",
++    "    for parent in PROJECT_ROOT.parents:\n",
++    "        if (parent / 'project').is_dir():\n",
++    "            PROJECT_ROOT = parent\n",
++    "            break\n",
++    "\n",
++    "sys.path.insert(0, str(PROJECT_ROOT))\n",
++    "\n",
++    "from project.config.data_config import load_parameter_ranges, load_transitions\n",
++    "from project.data.noise import add_noise_variety\n",
++    "from project.physics.forward import batch_physics_forward_multimol_vgrid\n",
++    "from project.physics.tips import Tips2021QTpy\n",
++    "from project.utils.lowess import lowess_value\n",
++    "\n",
++    "plt.rcParams['figure.figsize'] = (10, 4)\n",
++    "plt.rcParams['axes.grid'] = True\n"
++   ]
++  },
++  {
++   "cell_type": "code",
++   "metadata": {},
++   "execution_count": null,
++   "outputs": [],
++   "source": [
++    "torch.manual_seed(0)\n",
++    "np.random.seed(0)\n",
++    "\n",
++    "PARAMETERS_PATH = PROJECT_ROOT / 'project' / 'config' / 'data' / 'parameters_default.yaml'\n",
++    "TRANSITIONS_PATH = PROJECT_ROOT / 'project' / 'config' / 'data' / 'transitions_sample.yaml'\n",
++    "QTPY_PATH = PROJECT_ROOT / 'project' / 'examples' / 'notebooks' / 'data' / 'QTpy'\n",
++    "\n",
++    "parameter_ranges = load_parameter_ranges(PARAMETERS_PATH)\n",
++    "transitions_dict, poly_freq_map = load_transitions(TRANSITIONS_PATH, include_poly_freq=True)\n",
++    "\n",
++    "poly_freq_CH4 = poly_freq_map.get('CH4')\n",
++    "if poly_freq_CH4:\n",
++    "    poly_freq_CH4 = torch.tensor(poly_freq_CH4, dtype=torch.float64)\n",
++    "else:\n",
++    "    poly_freq_CH4 = None\n",
++    "\n",
++    "tipspy = Tips2021QTpy(QTPY_PATH, device='cpu')\n",
++    "\n",
++    "num_points = 1024\n",
++    "v_grid_idx = torch.arange(num_points, dtype=torch.float64)\n",
++    "\n",
++    "def mid_linear(name: str) -> float:\n",
++    "    lo, hi = parameter_ranges[name]\n",
++    "    return 0.5 * (lo + hi)\n",
++    "\n",
++    "def mid_log(name: str) -> float:\n",
++    "    lo, hi = parameter_ranges[name]\n",
++    "    return float(np.sqrt(lo * hi))\n",
++    "\n",
++    "sig0 = torch.tensor([mid_linear('sig0')], dtype=torch.float64)\n",
++    "dsig = torch.tensor([mid_linear('dsig')], dtype=torch.float64)\n",
++    "P = torch.tensor([mid_linear('P')], dtype=torch.float64)\n",
++    "T = torch.tensor([mid_linear('T')], dtype=torch.float64)\n",
++    "baseline_coeffs = torch.tensor(\n",
++    "    [[mid_linear('baseline0'), mid_linear('baseline1'), mid_linear('baseline2')]],\n",
++    "    dtype=torch.float64,\n",
++    ")\n",
++    "mf_dict = {\n",
++    "    'CH4': torch.tensor([mid_log('mf_CH4')], dtype=torch.float64),\n",
++    "    'H2O': torch.tensor([mid_log('mf_H2O')], dtype=torch.float64),\n",
++    "}\n",
++    "\n",
++    "clean_batch, freq_grid = batch_physics_forward_multimol_vgrid(\n",
++    "    sig0,\n",
++    "    dsig,\n",
++    "    poly_freq_CH4,\n",
++    "    v_grid_idx,\n",
++    "    baseline_coeffs,\n",
++    "    transitions_dict,\n",
++    "    P,\n",
++    "    T,\n",
++    "    mf_dict,\n",
++    "    tipspy=tipspy,\n",
++    "    device='cpu',\n",
++    ")\n",
++    "clean_reference = clean_batch[0].to(torch.float32)\n",
++    "wavenumber_axis = freq_grid[0].to(torch.float32)\n",
++    "baseline_reference = lowess_value(clean_reference, kind='start', win=30).to(torch.float32)\n",
++    "clean_reference_np = clean_reference.numpy()\n",
++    "axis_values = wavenumber_axis.numpy()\n"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "Visualisons le spectre propre qui servira de base à toutes les simulations de bruit."
++   ]
++  },
++  {
++   "cell_type": "code",
++   "metadata": {},
++   "execution_count": null,
++   "outputs": [],
++   "source": [
++    "fig, ax = plt.subplots()\n",
++    "ax.plot(axis_values, clean_reference_np, color='black', linewidth=2, label='Spectre propre')\n",
++    "ax.set_xlabel(\"Nombre d'onde (cm⁻¹)\")\n",
++    "ax.set_ylabel('Transmission normalisée')\n",
++    "ax.set_title('Spectre généré par le moteur physique interne')\n",
++    "ax.legend()\n",
++    "plt.show()\n"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Génération des échantillons bruités\n",
++    "\n",
++    "Nous balayons les valeurs de `noise_level` de 0.0 à 2.0 par pas de 0.1. Pour chaque tranche, cinq exemples indépendants sont créés via `add_noise_variety` en désactivant le pipeline de bruit *legacy* pour ne conserver que le profil complexe demandé."
++   ]
++  },
++  {
++   "cell_type": "code",
++   "metadata": {},
++   "execution_count": null,
++   "outputs": [],
++   "source": [
++    "noise_types = ['gaussian', 'shot', 'flicker', 'etaloning', 'glitches']\n",
++    "noise_levels = np.round(np.arange(0.0, 2.0 + 1e-6, 0.1), 1)\n",
++    "examples_per_level = 5\n",
++    "\n",
++    "noise_samples = {noise_type: {} for noise_type in noise_types}\n",
++    "\n",
++    "for t_idx, noise_type in enumerate(noise_types):\n",
++    "    for l_idx, level in enumerate(noise_levels):\n",
++    "        level_key = f\"{level:.1f}\"\n",
++    "        generator = torch.Generator(device='cpu').manual_seed(10_000 * t_idx + l_idx)\n",
++    "        batch_clean = clean_reference.unsqueeze(0).repeat(examples_per_level, 1)\n",
++    "        baseline_batch = baseline_reference.repeat(examples_per_level)\n",
++    "        noisy = add_noise_variety(\n",
++    "            batch_clean,\n",
++    "            generator=generator,\n",
++    "            baseline_norm=baseline_batch,\n",
++    "            complex={\n",
++    "                'noise_type': noise_type,\n",
++    "                'noise_level': float(level),\n",
++    "                'max_rel_to_line': 0.10,\n",
++    "                'mode': 'replace',\n",
++    "                'clip': (0.0, 1.5),\n",
++    "            },\n",
++    "            legacy_enabled=False,\n",
++    "        )\n",
++    "        noise_samples[noise_type][level_key] = noisy.detach().cpu().numpy()\n"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Visualisation interactive\n",
++    "\n",
++    "Utilisez les contrôles ci-dessous pour sélectionner un type de bruit et une tranche de `noise_level`. Le spectre propre est tracé en noir et les cinq réalisations correspondant à la tranche choisie sont affichées en couleur."
++   ]
++  },
++  {
++   "cell_type": "code",
++   "metadata": {},
++   "execution_count": null,
++   "outputs": [],
++   "source": [
++    "palette = plt.cm.viridis(np.linspace(0, 1, examples_per_level))\n",
++    "\n",
++    "noise_selector = widgets.Dropdown(\n",
++    "    options=[(nt.capitalize(), nt) for nt in noise_types],\n",
++    "    value='gaussian',\n",
++    "    description='Type:',\n",
++    ")\n",
++    "\n",
++    "level_selector = widgets.SelectionSlider(\n",
++    "    options=[(f\"{lvl:.1f}\", f\"{lvl:.1f}\") for lvl in noise_levels],\n",
++    "    value=f\"{noise_levels[0]:.1f}\",\n",
++    "    description='Niveau:',\n",
++    "    continuous_update=False,\n",
++    ")\n",
++    "\n",
++    "output = widgets.Output()\n",
++    "\n",
++    "def plot_examples(noise_type: str, level_key: str) -> None:\n",
++    "    output.clear_output(wait=True)\n",
++    "    examples = noise_samples[noise_type][level_key]\n",
++    "\n",
++    "    with output:\n",
++    "        fig, ax = plt.subplots(figsize=(10, 4))\n",
++    "        ax.plot(axis_values, clean_reference_np, color='black', linewidth=2, label='Propre')\n",
++    "        for idx in range(examples_per_level):\n",
++    "            ax.plot(axis_values, examples[idx], color=palette[idx], alpha=0.8, label=f'Exemple {idx + 1}')\n",
++    "        ax.set_xlabel(\"Nombre d'onde (cm⁻¹)\")\n",
++    "        ax.set_ylabel('Transmission normalisée')\n",
++    "        ax.set_title(f\"{noise_type.capitalize()} — noise_level = {level_key}\")\n",
++    "        ax.set_ylim(0.0, 1.4)\n",
++    "        ax.legend(loc='upper right', ncol=2)\n",
++    "        plt.show()\n",
++    "\n",
++    "def on_change(change):\n",
++    "    plot_examples(noise_selector.value, level_selector.value)\n",
++    "\n",
++    "noise_selector.observe(on_change, names='value')\n",
++    "level_selector.observe(on_change, names='value')\n",
++    "\n",
++    "controls = widgets.HBox([noise_selector, level_selector])\n",
++    "display(controls, output)\n",
++    "\n",
++    "plot_examples(noise_selector.value, level_selector.value)\n"
++   ]
++  },
++  {
++   "cell_type": "markdown",
++   "metadata": {},
++   "source": [
++    "## Statistiques rapides\n",
++    "\n",
++    "Le tableau suivant résume l'écart-type moyen du bruit ajouté pour chaque combinaison type/niveau, calculé en soustrayant le spectre propre. Il permet de visualiser globalement la croissance de l'amplitude du bruit lorsque `noise_level` augmente."
++   ]
++  },
++  {
++   "cell_type": "code",
++   "metadata": {},
++   "execution_count": null,
++   "outputs": [],
++   "source": [
++    "import pandas as pd\n",
++    "\n",
++    "rows = []\n",
++    "for noise_type in noise_types:\n",
++    "    for level_key, noisy in noise_samples[noise_type].items():\n",
++    "        residual = noisy - clean_reference_np\n",
++    "        rms = np.sqrt(np.mean(residual**2, axis=1))\n",
++    "        rows.append({'Type': noise_type, 'noise_level': float(level_key), 'RMS moyen': float(rms.mean())})\n",
++    "\n",
++    "summary_df = pd.DataFrame(rows).pivot(index='noise_level', columns='Type', values='RMS moyen')\n",
++    "display(summary_df)\n"
++   ]
++  }
++ ],
++ "metadata": {
++  "kernelspec": {
++   "display_name": "Python 3",
++   "language": "python",
++   "name": "python3"
++  },
++  "language_info": {
++   "name": "python",
++   "version": "3.10"
++  }
++ },
++ "nbformat": 4,
++ "nbformat_minor": 5
++}
+\ No newline at end of file


### PR DESCRIPTION
## Summary
- add a `legacy_enabled` flag to the noise augmentation helper so legacy noise can be disabled when only complex profiles are desired
- update the default noise configuration to disable legacy noise and always apply complex noise
- ensure the standalone `physae.py` helper respects the new toggle

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145dd32704832a85ced253ee97ce88)